### PR TITLE
Add scripts to rule them all

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,42 @@
 # Approved Premises API
 
-This is the backend for the Approved Premises service. Its API is consumed by the corresponding "UI" codebase ([approved-premises-ui](https://github.com/ministryofjustice/approved-premises-ui)). 
+This is the backend for the Approved Premises service. Its API is consumed by the corresponding "UI" codebase ([approved-premises-ui](https://github.com/ministryofjustice/approved-premises-ui)).
+
+## Prerequisites
+
+TBC
+
+## Setup
+
+When running the application for the first time, run the following command:
+
+```bash
+script/setup # TODO - this script is currently a stub
+```
+
+If you're coming back to the application after a certain amount of time, you can run:
+
+```bash
+script/bootstrap # TODO - this script is currently a stub
+```
+
+## Running the application
+
+To run the server, from the root directory, run:
+
+```bash
+script/server
+```
+
+This runs the project as a Spring Boot application on `localhost:8080`
+
+## Running the tests
+
+To run linting and tests, from the root directory, run:
+
+```bash
+script/test
+```
 
 ## OpenAPI documentation
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# script/bootstrap: Resolve all dependencies that the application requires to
+#                   run.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+echo "Bootstrap script not yet implemented"

--- a/script/server
+++ b/script/server
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# script/server: Launch the application and any extra required processes
+#                locally.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+echo "==> Starting server..."
+./gradlew bootRun

--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# script/setup: Set up the application for the first time after cloning, or set
+#               it back to the initial unused state.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+echo "Setup script not yet implemented"
+
+echo "==> Bootstrapping..."
+script/bootstrap

--- a/script/test
+++ b/script/test
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# script/test: Run the test suite for the application.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+echo "==> Running ktlint..."
+./gradlew ktlintCheck
+
+echo "==> Running tests..."
+./gradlew test
+
+


### PR DESCRIPTION
This adds some simple scripts to aid running in development. We use these in the frontend application, so it’s useful to mirror this approach in the API too, to aid with context switch. Currently the bootsrap and server scripts are stubs, as there’s nothing we (yet) need to do to bootstrap / setup the app, but they’re worth having around as a reminder to update them when we do start introducing external dependencies, like a database etc.