### PR TITLE
Add Person to Arrival and Booking schemas

### DIFF
--- a/src/main/resources/static/mini-manage-api-stubs.yml
+++ b/src/main/resources/static/mini-manage-api-stubs.yml
@@ -394,8 +394,8 @@ components:
         id:
           type: string
           format: uuid
-        CRN:
-          type: string
+        person: 
+          $ref: '#/components/schemas/Person'
         arrivalDate:
           type: string
           format: date
@@ -417,6 +417,8 @@ components:
         bookingID:
           type: string
           format: uuid
+        person: 
+          $ref: '#/components/schemas/Person'
         dateTime:
           type: string
           format: date


### PR DESCRIPTION
We need to return a person's name with a Booking and Arrival
I thought it would make sense to return a Person object which consists of a name and CRN

I'm not sure whether it would make sense to add a Person to the other events whilst I'm here (EG Nonarrival, Departure) - I feel they will need a Person too.