### PR TITLE
Refine premises representation

### DIFF
--- a/src/main/resources/static/mini-manage-api-stubs.yml
+++ b/src/main/resources/static/mini-manage-api-stubs.yml
@@ -378,16 +378,43 @@ components:
           type: string
         apCode:
           type: string
-        probationRegionId:
-          type: string
         postcode:
           type: string
         bedCount:
           type: integer
-        apAreaId:
-          type: string
+        probationRegion:
+          $ref: '#/components/schemas/ProbationRegion'
+        apArea:
+          $ref: '#/components/schemas/ApArea'
         localAuthorityArea:
+          $ref: '#/components/schemas/LocalAuthorityArea'
+    LocalAuthorityArea:
+      type: object
+      properties:
+        id:
           type: string
+          example: LEEDS
+        name:
+          type: string
+          example: Leeds City Council
+    ApArea:
+      type: object
+      properties:
+        id:
+          type: string
+          example: 1500001234
+        name:
+          type: string
+          example: Yorkshire & The Humber
+    ProbationRegion:
+      type: object
+      properties:
+        id:
+          type: string
+          example: 1500123456
+        name:
+          type: string
+          example: NPS North East Central Referrals
     BookingBody:
       type: object
       properties:

--- a/src/main/resources/static/mini-manage-api-stubs.yml
+++ b/src/main/resources/static/mini-manage-api-stubs.yml
@@ -376,12 +376,16 @@ components:
           format: uuid
         name:
           type: string
+          example: Hope House
         apCode:
           type: string
+          example: NEHOPE1
         postcode:
           type: string
+          example: LS1 3AD
         bedCount:
           type: integer
+          example: 22
         probationRegion:
           $ref: '#/components/schemas/ProbationRegion'
         apArea:


### PR DESCRIPTION
Rather than providing only the IDs of `probationRegion`, `apArea` and
`localAuthorityArea` we now define schemas for representing these entities
by which premises are grouped.

The UI can now both display their human-readable names and use their IDs
in communications with the API.

```
{
  "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
  "name": "Hope House",
  "apCode": "NEHOPE1",
  "postcode": "LS1 3AD",
  "bedCount": 22,
  "probationRegion": {
    "id": "1500123456",
    "name": "NPS North East Central Referrals"
  },
  "apArea": {
    "id": "1500001234",
    "name": "Yorkshire & The Humber"
  },
  "localAuthorityArea": {
    "id": "LEEDS",
    "name": "Leeds City Council"
  }
}
```