### PR TITLE
525 - Add get all premises endpoint

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,8 @@ dependencies {
   implementation("org.springdoc:springdoc-openapi-ui:$springDocVersion")
   implementation("org.springdoc:springdoc-openapi-kotlin:$springDocVersion")
   implementation("org.springdoc:springdoc-openapi-data-rest:$springDocVersion")
+
+  testImplementation("io.github.bluegroundltd:kfactory:1.0.0")
 }
 
 java {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
   kotlin("plugin.spring") version "1.6.21"
 
   id("org.openapi.generator") version "5.4.0"
+  id("org.jetbrains.kotlin.plugin.jpa") version "1.7.10"
 }
 
 configurations {
@@ -69,4 +70,8 @@ ktlint {
   filter {
     exclude("**/generated/**")
   }
+}
+
+allOpen {
+  annotations("javax.persistence.Entity")
 }

--- a/script/generate_migration
+++ b/script/generate_migration
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# script/generate_migration: Create an empty database migration, e.g.
+#                            script/generate_migration "my migration"
+
+set -e
+
+timestamp=`date "+%Y%m%d%H%M%S"`
+migration_name=`echo "$1" | awk '{print tolower($0)}' | tr ' ' '_'`
+filename="$(echo ${timestamp}__${migration_name}).sql"
+echo "Creating migration: $filename"
+touch "src/main/resources/db/migration/$filename"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -3,37 +3,18 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.PremisesApiDelegate
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.ApArea
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.LocalAuthorityArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.Premises
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.ProbationRegion
-import java.util.UUID
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PremisesService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PremisesTransformer
 
 @Service
-class PremisesController : PremisesApiDelegate {
+class PremisesController(
+  private val premisesService: PremisesService,
+  private val premisesTransformer: PremisesTransformer
+) : PremisesApiDelegate {
   override fun premisesGet(): ResponseEntity<List<Premises>> {
     return ResponseEntity.ok(
-      listOf(
-        Premises(
-          id = UUID.fromString("efd52239-f5cb-4b00-ab1a-9a4e3402fc58"),
-          name = "Beckenham Road",
-          apCode = "BELON",
-          postcode = "BR3 4LR",
-          bedCount = 20,
-          probationRegion = ProbationRegion(
-            id = "LON",
-            name = "London"
-          ),
-          apArea = ApArea(
-            id = "LON",
-            name = "London"
-          ),
-          localAuthorityArea = LocalAuthorityArea(
-            id = "CAM",
-            name = "Camden"
-          )
-        )
-      )
+      premisesService.getAllPremises().map(premisesTransformer::transformJpaToApi)
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApAreaEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApAreaEntity.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.OneToMany
+import javax.persistence.Table
+
+@Entity
+@Table(name = "ap_area")
+data class ApAreaEntity(
+  @Id
+  var id: UUID,
+  var name: String,
+  @OneToMany(mappedBy = "apArea")
+  var premises: MutableList<PremisesEntity>
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/LocalAuthorityAreaEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/LocalAuthorityAreaEntity.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.OneToMany
+import javax.persistence.Table
+
+@Entity
+@Table(name = "local_authority_area")
+data class LocalAuthorityAreaEntity(
+  @Id
+  var id: UUID,
+  var identifier: String,
+  var name: String,
+  @OneToMany(mappedBy = "localAuthorityArea")
+  var premises: MutableList<PremisesEntity>
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.Table
+
+@Entity
+@Table(name = "premises")
+data class PremisesEntity(
+  @Id
+  var id: UUID,
+  var name: String,
+  var apCode: String,
+  var postcode: String,
+  var totalBeds: Int,
+  @ManyToOne
+  @JoinColumn(name = "probation_region_id")
+  var probationRegion: ProbationRegionEntity,
+  @ManyToOne
+  @JoinColumn(name = "ap_area_id")
+  var apArea: ApAreaEntity,
+  @ManyToOne
+  @JoinColumn(name = "local_authority_area_id")
+  var localAuthorityArea: LocalAuthorityAreaEntity
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ProbationRegionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ProbationRegionEntity.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.OneToMany
+import javax.persistence.Table
+
+@Entity
+@Table(name = "probation_region")
+data class ProbationRegionEntity(
+  @Id
+  var id: UUID,
+  var identifier: String,
+  var name: String,
+  @OneToMany(mappedBy = "probationRegion")
+  var premises: MutableList<PremisesEntity>
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/repository/PremisesRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/repository/PremisesRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
+import java.util.UUID
+
+@Repository
+interface PremisesRepository : JpaRepository<PremisesEntity, UUID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.repository.PremisesRepository
+
+@Service
+class PremisesService(private val premisesRepository: PremisesRepository) {
+  fun getAllPremises(): List<PremisesEntity> = premisesRepository.findAll()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApAreaTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApAreaTransformer.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.ApArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
+
+@Component
+class ApAreaTransformer {
+  fun transformJpaToApi(jpa: ApAreaEntity) = ApArea(id = jpa.id, name = jpa.name)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/LocalAuthorityAreaTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/LocalAuthorityAreaTransformer.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.LocalAuthorityArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
+
+@Component
+class LocalAuthorityAreaTransformer {
+  fun transformJpaToApi(jpa: LocalAuthorityAreaEntity) = LocalAuthorityArea(id = jpa.id, identifier = jpa.identifier, name = jpa.name)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesTransformer.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.Premises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
+
+@Component
+class PremisesTransformer(
+  private val probationRegionTransformer: ProbationRegionTransformer,
+  private val apAreaTransformer: ApAreaTransformer,
+  private val localAuthorityAreaTransformer: LocalAuthorityAreaTransformer
+) {
+  fun transformJpaToApi(jpa: PremisesEntity): Premises {
+    return Premises(
+      id = jpa.id,
+      name = jpa.name,
+      apCode = jpa.apCode,
+      postcode = jpa.postcode,
+      bedCount = jpa.totalBeds,
+      probationRegion = probationRegionTransformer.transformJpaToApi(jpa.probationRegion),
+      apArea = apAreaTransformer.transformJpaToApi(jpa.apArea),
+      localAuthorityArea = localAuthorityAreaTransformer.transformJpaToApi(jpa.localAuthorityArea)
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ProbationRegionTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ProbationRegionTransformer.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.ProbationRegion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
+
+@Component
+class ProbationRegionTransformer {
+  fun transformJpaToApi(jpa: ProbationRegionEntity) = ProbationRegion(id = jpa.id, name = jpa.name)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ProbationRegionTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ProbationRegionTransformer.kt
@@ -6,5 +6,5 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegi
 
 @Component
 class ProbationRegionTransformer {
-  fun transformJpaToApi(jpa: ProbationRegionEntity) = ProbationRegion(id = jpa.id, name = jpa.name)
+  fun transformJpaToApi(jpa: ProbationRegionEntity) = ProbationRegion(id = jpa.id, identifier = jpa.identifier, name = jpa.name)
 }

--- a/src/main/resources/db/migration/20220803121537__premises_tables.sql
+++ b/src/main/resources/db/migration/20220803121537__premises_tables.sql
@@ -1,0 +1,36 @@
+CREATE TABLE ap_area (
+    id UUID NOT NULL,
+    name TEXT NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE local_authority_area (
+    id UUID NOT NULL,
+    identifier TEXT NOT NULL,
+    name TEXT NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE (identifier)
+);
+
+CREATE TABLE probation_region (
+    id UUID NOT NULL,
+    identifier TEXT NOT NULL,
+    name TEXT NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE (identifier)
+);
+
+CREATE TABLE premises (
+    id UUID NOT NULL,
+    name TEXT NOT NULL,
+    ap_code TEXT NOT NULL,
+    postcode TEXT NOT NULL,
+    total_beds INT NOT NULL,
+    probation_region_id UUID NOT NULL,
+    ap_area_id UUID NOT NULL,
+    local_authority_area_id UUID NOT NULL,
+    PRIMARY KEY(id),
+    FOREIGN KEY (probation_region_id) REFERENCES probation_region(id),
+    FOREIGN KEY (ap_area_id) REFERENCES ap_area(id),
+    FOREIGN KEY (probation_region_id) REFERENCES probation_region(id)
+);

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -7,7 +7,7 @@
     <springProperty scope="context" name="app" source="spring.application.name"/>
 
 
-    <springProfile name="dev || stdout">
+    <springProfile name="local || stdout">
         <appender name="consoleAppender" class="ch.qos.logback.core.helpers.NOPAppender"/>
         <appender name="logAppender" class="ch.qos.logback.core.ConsoleAppender">
             <layout class="ch.qos.logback.classic.PatternLayout">
@@ -16,7 +16,7 @@
         </appender>
     </springProfile>
 
-    <springProfile name="!(dev || stdout)">
+    <springProfile name="!(local || stdout)">
         <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
             <layout class="ch.qos.logback.classic.PatternLayout">
                 <Pattern>${LOG_PATTERN}</Pattern>

--- a/src/main/resources/static/mini-manage-api-stubs.yml
+++ b/src/main/resources/static/mini-manage-api-stubs.yml
@@ -584,6 +584,10 @@ components:
       properties:
         id:
           type: string
+          format: uuid
+          example: 6abb5fa3-e93f-4445-887b-30d081688f44
+        identifier:
+          type: string
           example: LEEDS
         name:
           type: string
@@ -593,7 +597,8 @@ components:
       properties:
         id:
           type: string
-          example: 1500001234
+          format: uuid
+          example: cd1c2d43-0b0b-4438-b0e3-d4424e61fb6a
         name:
           type: string
           example: Yorkshire & The Humber
@@ -602,7 +607,11 @@ components:
       properties:
         id:
           type: string
-          example: 1500123456
+          format: uuid
+          example: 952790c0-21d7-4fd6-a7e1-9018f08d8bb0
+        identifier:
+          type: string
+          example: NPSNE
         name:
           type: string
           example: NPS North East Central Referrals

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApAreaEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApAreaEntityFactory.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApAreaTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.util.UUID
+
+class ApAreaEntityFactory(
+  apAreaTestRepository: ApAreaTestRepository
+) : PersistedFactory<ApAreaEntity, UUID>(apAreaTestRepository) {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withName(name: String) = apply {
+    this.name = { name }
+  }
+
+  override fun produce(): ApAreaEntity = ApAreaEntity(
+    id = this.id(),
+    name = this.name(),
+    premises = mutableListOf()
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/LocalAuthorityEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/LocalAuthorityEntityFactory.kt
@@ -1,0 +1,35 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.LocalAuthorityAreaTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.util.UUID
+
+class LocalAuthorityEntityFactory(
+  localAuthorityAreaTestRepository: LocalAuthorityAreaTestRepository
+) : PersistedFactory<LocalAuthorityAreaEntity, UUID>(localAuthorityAreaTestRepository) {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var identifier: Yielded<String> = { randomStringUpperCase(5) }
+  private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withIdentifier(identifier: String) = apply {
+    this.identifier = { identifier }
+  }
+
+  fun withName(name: String) = apply {
+    this.name = { name }
+  }
+
+  override fun produce(): LocalAuthorityAreaEntity = LocalAuthorityAreaEntity(
+    id = this.id(),
+    identifier = this.identifier(),
+    name = this.name(),
+    premises = mutableListOf()
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PersistedFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PersistedFactory.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import org.springframework.data.jpa.repository.JpaRepository
+
+abstract class PersistedFactory<EntityType : Any, PrimaryKeyType : Any>(private val repository: JpaRepository<EntityType, PrimaryKeyType>) : Factory<EntityType> {
+  fun produceAndPersist(): EntityType = repository.saveAndFlush(this.produce())
+  fun produceAndPersistMultiple(amount: Int) = (1..amount).map { produceAndPersist() }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PremisesEntityFactory.kt
@@ -1,0 +1,82 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.PremisesTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomPostCode
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.lang.RuntimeException
+import java.util.UUID
+
+class PremisesEntityFactory(
+  premisesTestRepository: PremisesTestRepository
+) : PersistedFactory<PremisesEntity, UUID>(premisesTestRepository) {
+  private var probationRegion: Yielded<ProbationRegionEntity>? = null
+  private var apArea: Yielded<ApAreaEntity>? = null
+  private var localAuthorityArea: Yielded<LocalAuthorityAreaEntity>? = null
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
+  private var apCode: Yielded<String> = { randomStringUpperCase(5) }
+  private var postcode: Yielded<String> = { randomPostCode() }
+  private var totalBeds: Yielded<Int> = { randomInt(1, 100) }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withName(name: String) = apply {
+    this.name = { name }
+  }
+
+  fun withApCode(apCode: String) = apply {
+    this.apCode = { apCode }
+  }
+
+  fun withPostcode(postcode: String) = apply {
+    this.postcode = { postcode }
+  }
+
+  fun withTotalBeds(totalBeds: Int) = apply {
+    this.totalBeds = { totalBeds }
+  }
+
+  fun withProbationRegion(probationRegion: ProbationRegionEntity) = apply {
+    this.probationRegion = { probationRegion }
+  }
+
+  fun withYieldedProbationRegion(probationRegion: Yielded<ProbationRegionEntity>) = apply {
+    this.probationRegion = probationRegion
+  }
+
+  fun withApArea(apAreaEntity: ApAreaEntity) = apply {
+    this.apArea = { apAreaEntity }
+  }
+
+  fun withYieldedApArea(apAreaEntity: Yielded<ApAreaEntity>) = apply {
+    this.apArea = apAreaEntity
+  }
+
+  fun withLocalAuthorityArea(localAuthorityAreaEntity: LocalAuthorityAreaEntity) = apply {
+    this.localAuthorityArea = { localAuthorityAreaEntity }
+  }
+
+  fun withYieldedLocalAuthorityArea(localAuthorityAreaEntity: Yielded<LocalAuthorityAreaEntity>) = apply {
+    this.localAuthorityArea = localAuthorityAreaEntity
+  }
+
+  override fun produce(): PremisesEntity = PremisesEntity(
+    id = this.id(),
+    name = this.name(),
+    apCode = this.apCode(),
+    postcode = this.postcode(),
+    totalBeds = this.totalBeds(),
+    probationRegion = this.probationRegion?.invoke() ?: throw RuntimeException("Must provide a probation region"),
+    apArea = this.apArea?.invoke() ?: throw RuntimeException("Must provide an ApArea"),
+    localAuthorityArea = this.localAuthorityArea?.invoke() ?: throw RuntimeException("Must provide a local authority area")
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ProbationRegionEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ProbationRegionEntityFactory.kt
@@ -1,0 +1,35 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ProbationRegionTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.util.UUID
+
+class ProbationRegionEntityFactory(
+  probationRegionTestRepository: ProbationRegionTestRepository
+) : PersistedFactory<ProbationRegionEntity, UUID>(probationRegionTestRepository) {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var identifier: Yielded<String> = { randomStringUpperCase(5) }
+  private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withIdentifier(identifier: String) = apply {
+    this.identifier = { identifier }
+  }
+
+  fun withName(name: String) = apply {
+    this.name = { name }
+  }
+
+  override fun produce(): ProbationRegionEntity = ProbationRegionEntity(
+    id = this.id(),
+    identifier = this.identifier(),
+    name = this.name(),
+    premises = mutableListOf()
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
 import org.flywaydb.core.Flyway
-import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
@@ -19,8 +19,8 @@ abstract class IntegrationTestBase {
   @Autowired
   private lateinit var flyway: Flyway
 
-  @AfterEach
-  fun afterEach() {
+  @BeforeEach
+  fun beforeEach() {
     flyway.clean()
     flyway.migrate()
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
@@ -1,0 +1,115 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.ApArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.LocalAuthorityArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.Premises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.ProbationRegion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApAreaTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.LocalAuthorityAreaTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.PremisesTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ProbationRegionTestRepository
+import java.util.UUID
+
+class PremisesTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var objectMapper: ObjectMapper
+
+  @Autowired
+  lateinit var probationRegionRepository: ProbationRegionTestRepository
+
+  @Autowired
+  lateinit var apAreaRepository: ApAreaTestRepository
+
+  @Autowired
+  lateinit var localAuthorityAreaRepository: LocalAuthorityAreaTestRepository
+
+  @Autowired
+  lateinit var premisesRepository: PremisesTestRepository
+
+  @Test
+  fun `Get all Premises returns OK with correct body`() {
+    val pbReg1 = probationRegionRepository.saveAndFlush(
+      ProbationRegionEntity(id = UUID.fromString("d520e141-fb24-4f39-839b-666e69b29f17"), name = "PBREG1", identifier = "PBREG1ID", premises = mutableListOf())
+    )
+    val apArea1 = apAreaRepository.saveAndFlush(
+      ApAreaEntity(id = UUID.fromString("73f5aa38-a44a-41ce-b50f-6bb7df51cab7"), name = "APAREA1", premises = mutableListOf())
+    )
+    val localAuthorityArea1 = localAuthorityAreaRepository.saveAndFlush(
+      LocalAuthorityAreaEntity(id = UUID.fromString("311dc6ec-3925-4f42-aaca-13b6f3de96e0"), name = "ATAREA1", identifier = "ATAREA1ID", premises = mutableListOf())
+    )
+    premisesRepository.saveAndFlush(
+      PremisesEntity(
+        id = UUID.fromString("322e3614-2dc0-4166-8dec-63c016e20a0e"),
+        name = "Premises One",
+        apCode = "PREMONE",
+        postcode = "ST8ST8",
+        totalBeds = 1,
+        probationRegion = pbReg1,
+        apArea = apArea1,
+        localAuthorityArea = localAuthorityArea1
+      )
+    )
+
+    val pbReg2 = probationRegionRepository.saveAndFlush(
+      ProbationRegionEntity(id = UUID.fromString("c1585959-91d7-4ee6-b0c1-30df25cd4983"), name = "PBREG2", identifier = "PBREG2ID", premises = mutableListOf())
+    )
+    val apArea2 = apAreaRepository.saveAndFlush(
+      ApAreaEntity(id = UUID.fromString("1387e449-c8f7-486a-9f39-3d6cf0210ecd"), name = "APAREA2", premises = mutableListOf())
+    )
+    val localAuthorityArea2 = localAuthorityAreaRepository.saveAndFlush(
+      LocalAuthorityAreaEntity(id = UUID.fromString("6758b2a9-36f6-4b15-aff9-0902e121f5ac"), name = "ATAREA2", identifier = "ATAREA2ID", premises = mutableListOf())
+    )
+    premisesRepository.saveAndFlush(
+      PremisesEntity(
+        id = UUID.fromString("f04743a7-d9f1-4818-8847-5c15f4874ec0"),
+        name = "Premises Two",
+        apCode = "PREMTWO",
+        postcode = "ST8ST7",
+        totalBeds = 2,
+        probationRegion = pbReg2,
+        apArea = apArea2,
+        localAuthorityArea = localAuthorityArea2
+      )
+    )
+
+    val expectedJson = objectMapper.writeValueAsString(
+      listOf(
+        Premises(
+          id = UUID.fromString("322e3614-2dc0-4166-8dec-63c016e20a0e"),
+          name = "Premises One",
+          apCode = "PREMONE",
+          postcode = "ST8ST8",
+          bedCount = 1,
+          probationRegion = ProbationRegion(id = UUID.fromString("d520e141-fb24-4f39-839b-666e69b29f17"), name = "PBREG1"),
+          apArea = ApArea(id = UUID.fromString("73f5aa38-a44a-41ce-b50f-6bb7df51cab7"), name = "APAREA1"),
+          localAuthorityArea = LocalAuthorityArea(id = UUID.fromString("311dc6ec-3925-4f42-aaca-13b6f3de96e0"), name = "ATAREA1")
+        ),
+        Premises(
+          id = UUID.fromString("f04743a7-d9f1-4818-8847-5c15f4874ec0"),
+          name = "Premises Two",
+          apCode = "PREMTWO",
+          postcode = "ST8ST7",
+          bedCount = 2,
+          probationRegion = ProbationRegion(id = UUID.fromString("c1585959-91d7-4ee6-b0c1-30df25cd4983"), name = "PBREG2"),
+          apArea = ApArea(id = UUID.fromString("1387e449-c8f7-486a-9f39-3d6cf0210ecd"), name = "APAREA2"),
+          localAuthorityArea = LocalAuthorityArea(id = UUID.fromString("6758b2a9-36f6-4b15-aff9-0902e121f5ac"), name = "ATAREA2")
+        )
+      )
+    )
+
+    webTestClient.get()
+      .uri("/premises")
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .json(expectedJson)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
@@ -1,21 +1,22 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.ApArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.LocalAuthorityArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.Premises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.ProbationRegion
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApAreaTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.LocalAuthorityAreaTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.PremisesTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ProbationRegionTestRepository
-import java.util.UUID
 
 class PremisesTest : IntegrationTestBase() {
   @Autowired
@@ -33,76 +34,28 @@ class PremisesTest : IntegrationTestBase() {
   @Autowired
   lateinit var premisesRepository: PremisesTestRepository
 
+  private lateinit var probationRegionEntityFactory: ProbationRegionEntityFactory
+  private lateinit var apAreaEntityFactory: ApAreaEntityFactory
+  private lateinit var localAuthorityEntityFactory: LocalAuthorityEntityFactory
+  private lateinit var premisesEntityFactory: PremisesEntityFactory
+
+  @BeforeEach
+  fun setupFactories() {
+    probationRegionEntityFactory = ProbationRegionEntityFactory(probationRegionRepository)
+    apAreaEntityFactory = ApAreaEntityFactory(apAreaRepository)
+    localAuthorityEntityFactory = LocalAuthorityEntityFactory(localAuthorityAreaRepository)
+    premisesEntityFactory = PremisesEntityFactory(premisesRepository)
+  }
+
   @Test
   fun `Get all Premises returns OK with correct body`() {
-    val pbReg1 = probationRegionRepository.saveAndFlush(
-      ProbationRegionEntity(id = UUID.fromString("d520e141-fb24-4f39-839b-666e69b29f17"), name = "PBREG1", identifier = "PBREG1ID", premises = mutableListOf())
-    )
-    val apArea1 = apAreaRepository.saveAndFlush(
-      ApAreaEntity(id = UUID.fromString("73f5aa38-a44a-41ce-b50f-6bb7df51cab7"), name = "APAREA1", premises = mutableListOf())
-    )
-    val localAuthorityArea1 = localAuthorityAreaRepository.saveAndFlush(
-      LocalAuthorityAreaEntity(id = UUID.fromString("311dc6ec-3925-4f42-aaca-13b6f3de96e0"), name = "ATAREA1", identifier = "ATAREA1ID", premises = mutableListOf())
-    )
-    premisesRepository.saveAndFlush(
-      PremisesEntity(
-        id = UUID.fromString("322e3614-2dc0-4166-8dec-63c016e20a0e"),
-        name = "Premises One",
-        apCode = "PREMONE",
-        postcode = "ST8ST8",
-        totalBeds = 1,
-        probationRegion = pbReg1,
-        apArea = apArea1,
-        localAuthorityArea = localAuthorityArea1
-      )
-    )
+    val premises = premisesEntityFactory
+      .withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+      .withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+      .withYieldedProbationRegion { probationRegionEntityFactory.produceAndPersist() }
+      .produceAndPersistMultiple(10)
 
-    val pbReg2 = probationRegionRepository.saveAndFlush(
-      ProbationRegionEntity(id = UUID.fromString("c1585959-91d7-4ee6-b0c1-30df25cd4983"), name = "PBREG2", identifier = "PBREG2ID", premises = mutableListOf())
-    )
-    val apArea2 = apAreaRepository.saveAndFlush(
-      ApAreaEntity(id = UUID.fromString("1387e449-c8f7-486a-9f39-3d6cf0210ecd"), name = "APAREA2", premises = mutableListOf())
-    )
-    val localAuthorityArea2 = localAuthorityAreaRepository.saveAndFlush(
-      LocalAuthorityAreaEntity(id = UUID.fromString("6758b2a9-36f6-4b15-aff9-0902e121f5ac"), name = "ATAREA2", identifier = "ATAREA2ID", premises = mutableListOf())
-    )
-    premisesRepository.saveAndFlush(
-      PremisesEntity(
-        id = UUID.fromString("f04743a7-d9f1-4818-8847-5c15f4874ec0"),
-        name = "Premises Two",
-        apCode = "PREMTWO",
-        postcode = "ST8ST7",
-        totalBeds = 2,
-        probationRegion = pbReg2,
-        apArea = apArea2,
-        localAuthorityArea = localAuthorityArea2
-      )
-    )
-
-    val expectedJson = objectMapper.writeValueAsString(
-      listOf(
-        Premises(
-          id = UUID.fromString("322e3614-2dc0-4166-8dec-63c016e20a0e"),
-          name = "Premises One",
-          apCode = "PREMONE",
-          postcode = "ST8ST8",
-          bedCount = 1,
-          probationRegion = ProbationRegion(id = UUID.fromString("d520e141-fb24-4f39-839b-666e69b29f17"), name = "PBREG1"),
-          apArea = ApArea(id = UUID.fromString("73f5aa38-a44a-41ce-b50f-6bb7df51cab7"), name = "APAREA1"),
-          localAuthorityArea = LocalAuthorityArea(id = UUID.fromString("311dc6ec-3925-4f42-aaca-13b6f3de96e0"), name = "ATAREA1")
-        ),
-        Premises(
-          id = UUID.fromString("f04743a7-d9f1-4818-8847-5c15f4874ec0"),
-          name = "Premises Two",
-          apCode = "PREMTWO",
-          postcode = "ST8ST7",
-          bedCount = 2,
-          probationRegion = ProbationRegion(id = UUID.fromString("c1585959-91d7-4ee6-b0c1-30df25cd4983"), name = "PBREG2"),
-          apArea = ApArea(id = UUID.fromString("1387e449-c8f7-486a-9f39-3d6cf0210ecd"), name = "APAREA2"),
-          localAuthorityArea = LocalAuthorityArea(id = UUID.fromString("6758b2a9-36f6-4b15-aff9-0902e121f5ac"), name = "ATAREA2")
-        )
-      )
-    )
+    val expectedJson = objectMapper.writeValueAsString(premises.map(::premisesEntityToExpectedApiResponse))
 
     webTestClient.get()
       .uri("/premises")
@@ -112,4 +65,15 @@ class PremisesTest : IntegrationTestBase() {
       .expectBody()
       .json(expectedJson)
   }
+
+  private fun premisesEntityToExpectedApiResponse(premises: PremisesEntity) = Premises(
+    id = premises.id,
+    name = premises.name,
+    apCode = premises.apCode,
+    postcode = premises.postcode,
+    bedCount = premises.totalBeds,
+    probationRegion = ProbationRegion(id = premises.probationRegion.id, identifier = premises.probationRegion.identifier, name = premises.probationRegion.name),
+    apArea = ApArea(id = premises.apArea.id, name = premises.apArea.name),
+    localAuthorityArea = LocalAuthorityArea(id = premises.localAuthorityArea.id, identifier = premises.localAuthorityArea.identifier, name = premises.localAuthorityArea.name)
+  )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/ApAreaTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/ApAreaTestRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
+import java.util.UUID
+
+@Repository
+interface ApAreaTestRepository : JpaRepository<ApAreaEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/LocalAuthorityAreaTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/LocalAuthorityAreaTestRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
+import java.util.UUID
+
+@Repository
+interface LocalAuthorityAreaTestRepository : JpaRepository<LocalAuthorityAreaEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/PremisesTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/PremisesTestRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
+import java.util.UUID
+
+@Repository
+interface PremisesTestRepository : JpaRepository<PremisesEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/ProbationRegionTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/ProbationRegionTestRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
+import java.util.UUID
+
+@Repository
+interface ProbationRegionTestRepository : JpaRepository<ProbationRegionEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/RandomData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/RandomData.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
+
+import kotlin.random.Random
+
+private val charPoolMultiCaseNumbers = ('a'..'z') + ('A'..'Z') + ('0'..'9')
+private val charPoolUpperCase = ('A'..'Z').toList()
+private val charPoolNumbers = ('0'..'9').toList()
+
+private fun randomWithCharPool(charPool: List<Char>, length: Int) = (1..length)
+  .map { Random.nextInt(0, charPool.size) }
+  .map(charPool::get)
+  .joinToString("")
+
+fun randomStringMultiCaseWithNumbers(length: Int) = randomWithCharPool(charPoolMultiCaseNumbers, length)
+
+fun randomStringUpperCase(length: Int) = randomWithCharPool(charPoolUpperCase, length)
+
+fun randomNumberChars(length: Int) = randomWithCharPool(charPoolNumbers, length)
+
+fun randomPostCode() = randomStringUpperCase(2) + randomNumberChars(1) + " " +
+  randomStringUpperCase(2) + randomNumberChars(1)
+
+fun randomInt(min: Int, max: Int) = Random.nextInt(min, max)


### PR DESCRIPTION
Add migration that creates tables for Premises, Bed, Ap Area, Local Authority Area, Probation Region.
Add JPA entities for those tables.
Implement the GET all premises endpoint.

Also added kotlin-jpa/allOpen plugins which allow JPA to instantiate data classes without us providing a no-args constructor and making all properties nullable.