### PR TITLE
528  - Secure endpoints with HMPPS Auth tokens

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
             - gradle-{{ checksum "build.gradle.kts" }}
             - gradle-
       - run:
-          command: ./gradlew check
+          command: script/test
       - save_cache:
           paths:
             - ~/.gradle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,36 +11,10 @@ parameters:
     type: string
     default: dps-releases
 
-jobs:
-  validate:
-    executor:
-      name: hmpps/java
-      tag: "17.0"
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - gradle-{{ checksum "build.gradle.kts" }}
-            - gradle-
-      - run:
-          command: script/test
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: gradle-{{ checksum "build.gradle.kts" }}
-      - store_test_results:
-          path: build/test-results
-      - store_artifacts:
-          path: build/reports/tests
-
 workflows:
   version: 2
   build-test-and-deploy:
     jobs:
-      - validate:
-          filters:
-            tags:
-              ignore: /.*/
       - hmpps/helm_lint:
           name: helm_lint
       - hmpps/build_multiplatform_docker:
@@ -58,7 +32,6 @@ workflows:
               only:
                 - main
           requires:
-            - validate
             - build_docker
             - helm_lint
 #      - request-preprod-approval:

--- a/README.md
+++ b/README.md
@@ -41,6 +41,23 @@ script/development_database
 Then in the "Gradle" panel (`View->Tool Windows->Gradle` if not visible), expand `approved-premises-api`, `Tasks`, 
 `application` and right click on `bootRunDev` and select either Run or Debug.
 
+## Making requests to the application
+
+Most endpoints require a JWT from HMPPS Auth - an instance of this runs in Docker locally (started alongside the database) 
+on port 9091.  You can get a JWT by running:
+
+```
+script/get_client_credentials_jwt
+```
+
+The `access_token` value in the output is the JWT.  These are valid for 20 minutes.
+
+This value is then included in the Authorization header on requests to the API, as a bearer token, e.g.
+
+```
+Authorization: Bearer {the JWT}
+```
+
 ## Running the tests
 
 To run linting and tests, from the root directory, run:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.3.3"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.4.1"
   kotlin("plugin.spring") version "1.6.21"
 
   id("org.openapi.generator") version "5.4.0"
@@ -78,7 +78,7 @@ openApiGenerate {
 
 ktlint {
   filter {
-    exclude("**/generated/**")
+    exclude { it.file.path.contains("$buildDir${File.separator}generated${File.separator}") }
   }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,13 @@ dependencies {
 
   implementation("org.zalando:problem-spring-web-starter:0.27.0")
 
+  implementation("org.springframework.boot:spring-boot-starter-security")
+  implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
+
   testImplementation("io.github.bluegroundltd:kfactory:1.0.0")
+  testImplementation("io.jsonwebtoken:jjwt-api:0.11.5")
+  testRuntimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
+  testRuntimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
 }
 
 java {

--- a/doc/how-to/add_new_endpoint.md
+++ b/doc/how-to/add_new_endpoint.md
@@ -34,3 +34,19 @@ To create a new endpoint on a top-level path:
    with your implement, e.g.
     
    ![](./images/implement-delegate-method.png)
+
+ - You will then need to add a security configuration entry for your endpoint
+
+   In `src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt::securityFilterChain` add a new entry:
+   
+   ```
+   .mvcMatchers(HttpMethod.GET, "/premises").permitAll() //Allows any client to access the endpoint (even without a JWT)
+   .mvcMatchers(HttpMethod.GET, "/premises").authenticated() //Allows any client presenting a valid HMPPS JWT to acess the endpoint
+   .mvcMatchers(HttpMethod.GET, "/premises").hasAuthority("ROLE_interventions") //Allows only clients presenting a valid HMPPS JWT with the ROLE_interventions authority to access the endpoint
+   ```
+
+   If you need to access information about the requester from within the endpoint code, you can do so via the following:
+
+   ```
+   val principal = SecurityContextHolder.getContext().authentication as AuthAwareAuthenticationToken
+   ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,5 +11,16 @@ services:
     ports:
       - "5432:5432"
 
+  hmpps-auth:
+    image: quay.io/hmpps/hmpps-auth:latest
+    ports:
+      - "9091:8080"
+    healthcheck:
+      test:
+        [ "CMD", "curl", "-f", "http://localhost:8080/auth/health" ]
+    environment:
+      - SPRING_PROFILES_ACTIVE=dev
+      - APPLICATION_AUTHENTICATION_UI_ALLOWLIST=0.0.0.0/0
+
 volumes:
   database-data-development:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     environment:
       - SPRING_PROFILES_ACTIVE=dev
       - APPLICATION_AUTHENTICATION_UI_ALLOWLIST=0.0.0.0/0
+      - SPRING_H2_CONSOLE_SETTINGS_WEBALLOWOTHERS=true
 
 volumes:
   database-data-development:

--- a/script/get_client_credentials_jwt
+++ b/script/get_client_credentials_jwt
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# script/get_client_credentials_jwt: Get a client_credentials JWT from a local docker instance of HMPPS Auth
+
+set -e
+
+curl --location -s --request POST 'localhost:9091/auth/oauth/token?grant_type=client_credentials' \
+--header 'Content-Type: application/json' \
+--header 'Content-Length: 0' \
+--header 'Authorization: Basic YXBwcm92ZWQtcHJlbWlzZXMtYXBpOmNsaWVudHNlY3JldA==' \

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -1,0 +1,114 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Bean
+import org.springframework.core.convert.converter.Converter
+import org.springframework.http.HttpMethod
+import org.springframework.security.authentication.AbstractAuthenticationToken
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.config.web.servlet.invoke
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.security.web.SecurityFilterChain
+
+@EnableWebSecurity
+class OAuth2ResourceServerSecurityConfiguration {
+  @Bean
+  @Throws(Exception::class)
+  fun securityFilterChain(http: HttpSecurity, @Autowired objectMapper: ObjectMapper): SecurityFilterChain {
+    http {
+      authorizeHttpRequests {
+        authorize(HttpMethod.GET, "/health/**", permitAll)
+        authorize(HttpMethod.GET, "/swagger-ui/**", permitAll)
+        authorize(HttpMethod.GET, "/favicon.ico", permitAll)
+        authorize(HttpMethod.GET, "/info", permitAll)
+        authorize(anyRequest, authenticated)
+      }
+
+      anonymous { disable() }
+
+      oauth2ResourceServer {
+        jwt { jwtAuthenticationConverter = AuthAwareTokenConverter() }
+
+        authenticationEntryPoint = AuthenticationEntryPoint { _, response, _ ->
+          response.apply {
+            status = 401
+            contentType = "application/problem+json"
+            characterEncoding = "UTF-8"
+
+            writer.write(
+              objectMapper.writeValueAsString(
+                object {
+                  val title = "Unauthenticated"
+                  val status = 401
+                  val detail =
+                    "A valid HMPPS Auth JWT must be supplied via bearer authentication to access this endpoint"
+                }
+              )
+            )
+          }
+        }
+      }
+
+      sessionManagement { sessionCreationPolicy = SessionCreationPolicy.STATELESS }
+    }
+
+    return http.build()
+  }
+}
+
+class AuthAwareTokenConverter : Converter<Jwt, AbstractAuthenticationToken> {
+  private val jwtGrantedAuthoritiesConverter: Converter<Jwt, Collection<GrantedAuthority>> =
+    JwtGrantedAuthoritiesConverter()
+
+  override fun convert(jwt: Jwt): AbstractAuthenticationToken {
+    val claims = jwt.claims
+    val principal = findPrincipal(claims)
+    val authorities = extractAuthorities(jwt)
+    return AuthAwareAuthenticationToken(jwt, principal, authorities)
+  }
+
+  private fun findPrincipal(claims: Map<String, Any?>): String {
+    return if (claims.containsKey(CLAIM_USERNAME)) {
+      claims[CLAIM_USERNAME] as String
+    } else if (claims.containsKey(CLAIM_USER_ID)) {
+      claims[CLAIM_USER_ID] as String
+    } else {
+      claims[CLAIM_CLIENT_ID] as String
+    }
+  }
+
+  private fun extractAuthorities(jwt: Jwt): Collection<GrantedAuthority> {
+    val authorities = mutableListOf<GrantedAuthority>().apply { addAll(jwtGrantedAuthoritiesConverter.convert(jwt)!!) }
+    if (jwt.claims.containsKey(CLAIM_AUTHORITY)) {
+      @Suppress("UNCHECKED_CAST")
+      val claimAuthorities = (jwt.claims[CLAIM_AUTHORITY] as Collection<String>).toList()
+      authorities.addAll(claimAuthorities.map(::SimpleGrantedAuthority))
+    }
+    return authorities.toSet()
+  }
+
+  companion object {
+    const val CLAIM_USERNAME = "user_name"
+    const val CLAIM_USER_ID = "user_id"
+    const val CLAIM_CLIENT_ID = "client_id"
+    const val CLAIM_AUTHORITY = "authorities"
+  }
+}
+
+class AuthAwareAuthenticationToken(
+  jwt: Jwt,
+  private val aPrincipal: String,
+  authorities: Collection<GrantedAuthority>
+) : JwtAuthenticationToken(jwt, authorities) {
+  override fun getPrincipal(): String {
+    return aPrincipal
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ExceptionHandling.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ExceptionHandling.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.problem
+
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.zalando.problem.StatusType
+import org.zalando.problem.ThrowableProblem
+import org.zalando.problem.spring.common.AdviceTrait
+import org.zalando.problem.spring.web.advice.ProblemHandling
+
+@ControllerAdvice
+class ExceptionHandling : ProblemHandling {
+  override fun toProblem(throwable: Throwable, status: StatusType): ThrowableProblem? {
+    if (throwable is AuthenticationCredentialsNotFoundException) {
+      return UnauthenticatedProblem()
+    }
+
+    if (throwable is AccessDeniedException) {
+      return ForbiddenProblem()
+    }
+
+    return AdviceTraitDefault().toProblem(throwable, status)
+  }
+}
+
+private class AdviceTraitDefault : AdviceTrait

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ForbiddenProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ForbiddenProblem.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.problem
+
+import org.zalando.problem.AbstractThrowableProblem
+import org.zalando.problem.Exceptional
+import org.zalando.problem.Status
+
+class ForbiddenProblem() : AbstractThrowableProblem(null, "Forbidden", Status.FORBIDDEN, "You are not authorized to access this endpoint") {
+  override fun getCause(): Exceptional? {
+    return null
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/UnauthenticatedProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/UnauthenticatedProblem.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.problem
+
+import org.zalando.problem.AbstractThrowableProblem
+import org.zalando.problem.Exceptional
+import org.zalando.problem.Status
+
+class UnauthenticatedProblem() : AbstractThrowableProblem(null, "Unauthenticated", Status.UNAUTHORIZED, "A valid HMPPS Auth JWT must be supplied via bearer authentication to access this endpoint") {
+  override fun getCause(): Exceptional? {
+    return null
+  }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -6,3 +6,7 @@ spring:
     url: jdbc:postgresql://localhost:5432/approved_premises_localdev
   jpa:
     database: postgresql
+
+hmpps:
+  auth:
+    url: http://localhost:9091/auth

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,12 @@ spring:
     hibernate:
       ddl-auto: none
 
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          jwk-set-uri: ${hmpps.auth.url}/.well-known/jwks.json
+
 springdoc:
   swagger-ui:
     url: "mini-manage-api-stubs.yml"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AuthTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AuthTest.kt
@@ -1,0 +1,73 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.JwtAuthHelper
+import java.time.Duration
+
+class AuthTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var jwtAuthHelper: JwtAuthHelper
+
+  @Test
+  fun `Providing no JWT to a secured endpoint returns 401`() {
+    webTestClient.get()
+      .uri("/premises")
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+      .expectBody()
+      .jsonPath("title").isEqualTo("Unauthenticated")
+      .jsonPath("status").isEqualTo(401)
+      .jsonPath("detail").isEqualTo("A valid HMPPS Auth JWT must be supplied via bearer authentication to access this endpoint")
+  }
+
+  @Test
+  fun `Providing expired JWT to a secured endpoint returns 401`() {
+    val jwt = jwtAuthHelper.createJwt(
+      subject = "some-api",
+      expiryTime = Duration.ofMinutes(-2)
+    )
+
+    webTestClient.get()
+      .uri("/premises")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+      .expectBody()
+      .jsonPath("title").isEqualTo("Unauthenticated")
+      .jsonPath("status").isEqualTo(401)
+      .jsonPath("detail").isEqualTo("A valid HMPPS Auth JWT must be supplied via bearer authentication to access this endpoint")
+  }
+
+  @Test
+  fun `Providing malformed JWT to a secured endpoint returns 401`() {
+    webTestClient.get()
+      .uri("/premises")
+      .header("Authorization", "Bearer sdhidsofhoi")
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+      .expectBody()
+      .jsonPath("title").isEqualTo("Unauthenticated")
+      .jsonPath("status").isEqualTo(401)
+      .jsonPath("detail").isEqualTo("A valid HMPPS Auth JWT must be supplied via bearer authentication to access this endpoint")
+  }
+
+  @Test
+  fun `Providing JWT signed by wrong private key to a secured endpoint returns 401`() {
+    val jwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhcHByb3ZlZC1wcmVtaXNlcy1hcGkiLCJncmFudF90eXBlIjoiY2xpZW50X2NyZWRlbnRpYWxzIiwic2NvcGUiOlsicmVhZCJdLCJhdXRoX3NvdXJjZSI6Im5vbmUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjkwOTEvYXV0aC9pc3N1ZXIiLCJleHAiOjI2NTk3MDQ5NDAsImF1dGhvcml0aWVzIjpbIlJPTEVfSU5URVJWRU5USU9OUyIsIlJPTEVfT0FTWVNfUkVBRF9PTkxZIiwiUk9MRV9DT01NVU5JVFkiLCJST0xFX0dMT0JBTF9TRUFSQ0giLCJST0xFX0NPTU1VTklUWV9VU0VSUyIsIlJPTEVfUklTS19TVU1NQVJZIl0sImp0aSI6ImlTSEtsTXJ1aXFUNjF0dTNXVFFqckE2WWJfTSIsImNsaWVudF9pZCI6ImFwcHJvdmVkLXByZW1pc2VzLWFwaSJ9.Cr7Nl09vjUpyieddsJwyQF02nmqhR6PbM4xePA47ukkyhhctE4SwqpOAO5D5OIstr9ePnlmF_Tug7HZ6-SLF8lBnN9C_M2-74d8127gPkQxjWsGnAKIxAGDnwLjtwV1UpSvS0p-Phg3cBTGiq6_HABEuh2JSD67eJS0ZaqNPUXXp2kTfi1ZJXA1ysxFKvAP5qYHbBpYWfvFq9Wkpsrq4sM41yjzS7hmkpaEUAYvKUdYefeRAT6nMCU6pfkEOoCmXkMTf6n6rJ1HxxTvkucZwEQk1dOKZUH0d_AOjZy5RAXiSRzgiYsMfB02gvn2T0FfOyjkjKXgVDsFc2yf3bd6P0g"
+
+    webTestClient.get()
+      .uri("/premises")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+      .expectBody()
+      .jsonPath("title").isEqualTo("Unauthenticated")
+      .jsonPath("status").isEqualTo(401)
+      .jsonPath("detail").isEqualTo("A valid HMPPS Auth JWT must be supplied via bearer authentication to access this endpoint")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
@@ -17,11 +17,16 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApAreaTestRep
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.LocalAuthorityAreaTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.PremisesTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ProbationRegionTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.JwtAuthHelper
+import java.time.Duration
 import java.util.UUID
 
 class PremisesTest : IntegrationTestBase() {
   @Autowired
   lateinit var objectMapper: ObjectMapper
+
+  @Autowired
+  lateinit var jwtAuthHelper: JwtAuthHelper
 
   @Autowired
   lateinit var probationRegionRepository: ProbationRegionTestRepository
@@ -58,8 +63,14 @@ class PremisesTest : IntegrationTestBase() {
 
     val expectedJson = objectMapper.writeValueAsString(premises.map(::premisesEntityToExpectedApiResponse))
 
+    val jwt = jwtAuthHelper.createJwt(
+      subject = "some-api",
+      expiryTime = Duration.ofMinutes(2)
+    )
+
     webTestClient.get()
       .uri("/premises")
+      .header("Authorization", "Bearer $jwt")
       .exchange()
       .expectStatus()
       .isOk
@@ -78,8 +89,14 @@ class PremisesTest : IntegrationTestBase() {
     val premisesToGet = premises[2]
     val expectedJson = objectMapper.writeValueAsString(premisesEntityToExpectedApiResponse(premises[2]))
 
+    val jwt = jwtAuthHelper.createJwt(
+      subject = "some-api",
+      expiryTime = Duration.ofMinutes(2)
+    )
+
     webTestClient.get()
       .uri("/premises/${premisesToGet.id}")
+      .header("Authorization", "Bearer $jwt")
       .exchange()
       .expectStatus()
       .isOk
@@ -91,8 +108,14 @@ class PremisesTest : IntegrationTestBase() {
   fun `Get Premises by ID returns Not Found with correct body`() {
     val idToRequest = UUID.randomUUID().toString()
 
+    val jwt = jwtAuthHelper.createJwt(
+      subject = "some-api",
+      expiryTime = Duration.ofMinutes(2)
+    )
+
     webTestClient.get()
       .uri("/premises/$idToRequest")
+      .header("Authorization", "Bearer $jwt")
       .exchange()
       .expectHeader().contentType("application/problem+json")
       .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/JwtAuthHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/JwtAuthHelper.kt
@@ -1,0 +1,65 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
+
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm
+import org.springframework.context.annotation.Bean
+import org.springframework.http.HttpHeaders
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
+import org.springframework.stereotype.Component
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.interfaces.RSAPublicKey
+import java.time.Duration
+import java.util.Date
+import java.util.UUID
+
+@Component
+class JwtAuthHelper {
+  private val keyPair: KeyPair
+
+  init {
+    val gen = KeyPairGenerator.getInstance("RSA")
+    gen.initialize(2048)
+    keyPair = gen.generateKeyPair()
+  }
+
+  @Bean
+  fun jwtDecoder(): JwtDecoder = NimbusJwtDecoder.withPublicKey(keyPair.public as RSAPublicKey).build()
+
+  fun setAuthorisation(
+    user: String = "AUTH_ADM",
+    roles: List<String> = listOf(),
+    scopes: List<String> = listOf()
+  ): (HttpHeaders) -> Unit {
+    val token = createJwt(
+      subject = user,
+      scope = scopes,
+      expiryTime = Duration.ofHours(1L),
+      roles = roles
+    )
+    return { it.set(HttpHeaders.AUTHORIZATION, "Bearer $token") }
+  }
+
+  internal fun createJwt(
+    subject: String?,
+    scope: List<String>? = listOf(),
+    roles: List<String>? = listOf(),
+    expiryTime: Duration = Duration.ofHours(1),
+    jwtId: String = UUID.randomUUID().toString()
+  ): String =
+    mutableMapOf<String, Any>()
+      .also { subject?.let { subject -> it["user_name"] = subject } }
+      .also { it["client_id"] = "nomis-prisoner" }
+      .also { roles?.let { roles -> it["authorities"] = roles } }
+      .also { scope?.let { scope -> it["scope"] = scope } }
+      .let {
+        Jwts.builder()
+          .setId(jwtId)
+          .setSubject(subject)
+          .addClaims(it.toMap())
+          .setExpiration(Date(System.currentTimeMillis() + expiryTime.toMillis()))
+          .signWith(SignatureAlgorithm.RS256, keyPair.private)
+          .compact()
+      }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -13,3 +13,7 @@ spring:
     url: jdbc:postgresql://localhost:5433/approved_premises_integration_test
   jpa:
     database: postgresql
+
+hmpps:
+  auth:
+    url: http://localhost:9092/auth


### PR DESCRIPTION
Setup Spring Security to protect endpoints, must now present a valid HMPPS Auth JWT.

Added way of generating arbitrary JWTs with the private key that HMPPS Auth uses in the containerized version to be used in the tests - setup tests to use containerized HMPPS Auth.

Added convenience script to get a client_credentials JWT from containerized HMPPS Auth.