### PR TITLE
Add datasource related env vars

### DIFF
--- a/helm_deploy/approved-premises-api/values.yaml
+++ b/helm_deploy/approved-premises-api/values.yaml
@@ -22,6 +22,8 @@ generic-service:
     SPRING_PROFILES_ACTIVE: "logstash"
     APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY)"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
+    SPRING_DATASOURCE_DRIVERCLASSNAME: org.postgresql.Driver
+    SPRING_JPA_DATABASE: postgresql
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:
@@ -31,6 +33,8 @@ generic-service:
   namespace_secrets:
     approved-premises-api:
       APPINSIGHTS_INSTRUMENTATIONKEY: "APPINSIGHTS_INSTRUMENTATIONKEY"
+    rds-postgresql-instance-output:
+      SPRING_DATASOURCE_URL: "url"
 
   allowlist:
     office: "217.33.148.210/32"


### PR DESCRIPTION
This adds the `SPRING_DATASOURCE_DRIVERCLASSNAME` as a plaintext env var, and loads the `SPRING_DATASOURCE_URL` secret in the format `jdbc:postgres://${username}:${password}@${endpoint}/${dbname}`