### PR TITLE
Table names pluralise

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApAreaEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApAreaEntity.kt
@@ -7,7 +7,7 @@ import javax.persistence.OneToMany
 import javax.persistence.Table
 
 @Entity
-@Table(name = "ap_area")
+@Table(name = "ap_areas")
 data class ApAreaEntity(
   @Id
   var id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ArrivalEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ArrivalEntity.kt
@@ -10,7 +10,7 @@ import javax.persistence.OneToOne
 import javax.persistence.Table
 
 @Entity
-@Table(name = "arrival")
+@Table(name = "arrivals")
 data class ArrivalEntity(
   @Id
   val id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
 import java.time.LocalDate
 import java.util.Objects
 import java.util.UUID
@@ -9,6 +11,9 @@ import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
 import javax.persistence.OneToOne
 import javax.persistence.Table
+
+@Repository
+interface BookingRepository : JpaRepository<BookingEntity, UUID>
 
 @Entity
 @Table(name = "bookings")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -11,7 +11,7 @@ import javax.persistence.OneToOne
 import javax.persistence.Table
 
 @Entity
-@Table(name = "booking")
+@Table(name = "bookings")
 data class BookingEntity(
   @Id
   val id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CancellationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CancellationEntity.kt
@@ -10,7 +10,7 @@ import javax.persistence.OneToOne
 import javax.persistence.Table
 
 @Entity
-@Table(name = "cancellation")
+@Table(name = "cancellations")
 data class CancellationEntity(
   @Id
   val id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DepartureEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DepartureEntity.kt
@@ -11,7 +11,7 @@ import javax.persistence.OneToOne
 import javax.persistence.Table
 
 @Entity
-@Table(name = "departure")
+@Table(name = "departures")
 data class DepartureEntity(
   @Id
   val id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DepartureReasonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DepartureReasonEntity.kt
@@ -6,7 +6,7 @@ import javax.persistence.Id
 import javax.persistence.Table
 
 @Entity
-@Table(name = "departure_reason")
+@Table(name = "departure_reasons")
 data class DepartureReasonEntity(
   @Id
   val id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DestinationProviderEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DestinationProviderEntity.kt
@@ -1,9 +1,14 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
 import java.util.UUID
 import javax.persistence.Entity
 import javax.persistence.Id
 import javax.persistence.Table
+
+@Repository
+interface DestinationProviderRepository : JpaRepository<DestinationProviderEntity, UUID>
 
 @Entity
 @Table(name = "destination_providers")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DestinationProviderEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DestinationProviderEntity.kt
@@ -6,7 +6,7 @@ import javax.persistence.Id
 import javax.persistence.Table
 
 @Entity
-@Table(name = "destination_provider")
+@Table(name = "destination_providers")
 data class DestinationProviderEntity(
   @Id
   val id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/LocalAuthorityAreaEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/LocalAuthorityAreaEntity.kt
@@ -7,7 +7,7 @@ import javax.persistence.OneToMany
 import javax.persistence.Table
 
 @Entity
-@Table(name = "local_authority_area")
+@Table(name = "local_authority_areas")
 data class LocalAuthorityAreaEntity(
   @Id
   var id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/MoveOnCategoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/MoveOnCategoryEntity.kt
@@ -6,7 +6,7 @@ import javax.persistence.Id
 import javax.persistence.Table
 
 @Entity
-@Table(name = "move_on_category")
+@Table(name = "move_on_categories")
 data class MoveOnCategoryEntity(
   @Id
   val id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/NonArrivalEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/NonArrivalEntity.kt
@@ -10,7 +10,7 @@ import javax.persistence.OneToOne
 import javax.persistence.Table
 
 @Entity
-@Table(name = "non_arrival")
+@Table(name = "non_arrivals")
 data class NonArrivalEntity(
   @Id
   val id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PersonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PersonEntity.kt
@@ -9,7 +9,7 @@ import javax.persistence.OneToOne
 import javax.persistence.Table
 
 @Entity
-@Table(name = "person")
+@Table(name = "people")
 data class PersonEntity(
   @Id
   val id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PersonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PersonEntity.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
 import java.util.Objects
 import java.util.UUID
 import javax.persistence.Entity
@@ -7,6 +9,9 @@ import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.OneToOne
 import javax.persistence.Table
+
+@Repository
+interface PersonRepository : JpaRepository<PersonEntity, UUID>
 
 @Entity
 @Table(name = "people")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
 import java.util.UUID
 import javax.persistence.Entity
 import javax.persistence.Id
@@ -7,6 +9,9 @@ import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
 import javax.persistence.OneToMany
 import javax.persistence.Table
+
+@Repository
+interface PremisesRepository : JpaRepository<PremisesEntity, UUID>
 
 @Entity
 @Table(name = "premises")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ProbationRegionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ProbationRegionEntity.kt
@@ -7,7 +7,7 @@ import javax.persistence.OneToMany
 import javax.persistence.Table
 
 @Entity
-@Table(name = "probation_region")
+@Table(name = "probation_regions")
 data class ProbationRegionEntity(
   @Id
   var id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/repository/BookingRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/repository/BookingRepository.kt
@@ -1,9 +1,0 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.repository
-
-import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.stereotype.Repository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
-import java.util.UUID
-
-@Repository
-interface BookingRepository : JpaRepository<BookingEntity, UUID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/repository/DestinationProviderRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/repository/DestinationProviderRepository.kt
@@ -1,9 +1,0 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.repository
-
-import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.stereotype.Repository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DestinationProviderEntity
-import java.util.UUID
-
-@Repository
-interface DestinationProviderRepository : JpaRepository<DestinationProviderEntity, UUID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/repository/PersonRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/repository/PersonRepository.kt
@@ -1,9 +1,0 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.repository
-
-import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.stereotype.Repository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PersonEntity
-import java.util.UUID
-
-@Repository
-interface PersonRepository : JpaRepository<PersonEntity, UUID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/repository/PremisesRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/repository/PremisesRepository.kt
@@ -1,9 +1,0 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.repository
-
-import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.stereotype.Repository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
-import java.util.UUID
-
-@Repository
-interface PremisesRepository : JpaRepository<PremisesEntity, UUID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.repository.PremisesRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
 import java.util.UUID
 
 @Service

--- a/src/main/resources/db/migration/20220811100325__pluralize_table_names.sql
+++ b/src/main/resources/db/migration/20220811100325__pluralize_table_names.sql
@@ -1,0 +1,12 @@
+ALTER TABLE ap_area RENAME TO ap_areas;
+ALTER TABLE local_authority_area RENAME TO local_authority_areas;
+ALTER TABLE probation_region RENAME TO probation_regions;
+ALTER TABLE departure_reason RENAME TO departure_reasons;
+ALTER TABLE move_on_category RENAME TO move_on_categories;
+ALTER TABLE destination_provider RENAME TO destination_providers;
+ALTER TABLE booking RENAME TO bookings;
+ALTER TABLE person RENAME TO people;
+ALTER TABLE arrival RENAME TO arrivals;
+ALTER TABLE departure RENAME TO departures;
+ALTER TABLE non_arrival RENAME TO non_arrivals;
+ALTER TABLE cancellation RENAME TO cancellations;


### PR DESCRIPTION
Pluralise all of the tables names for consistency with other HMPPS projects.

Move the spring-data interfaces to live alongside their respective JPA models.