### PR TITLE
(607) Add a cancellation reasons api endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReferenceDataController.kt
@@ -3,12 +3,15 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.ReferenceDataApiDelegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.CancellationReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.DepartureReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.DestinationProvider
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.MoveOnCategory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DestinationProviderRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CancellationReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DepartureReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DestinationProviderTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.MoveOnCategoryTransformer
@@ -18,9 +21,11 @@ class ReferenceDataController(
   private val departureReasonRepository: DepartureReasonRepository,
   private val moveOnCategoryRepository: MoveOnCategoryRepository,
   private val destinationProviderRepository: DestinationProviderRepository,
+  private val cancellationReasonRepository: CancellationReasonRepository,
   private val departureReasonTransformer: DepartureReasonTransformer,
   private val moveOnCategoryTransformer: MoveOnCategoryTransformer,
-  private val destinationProviderTransformer: DestinationProviderTransformer
+  private val destinationProviderTransformer: DestinationProviderTransformer,
+  private val cancellationReasonTransformer: CancellationReasonTransformer
 ) : ReferenceDataApiDelegate {
   override fun referenceDataDepartureReasonsGet(): ResponseEntity<List<DepartureReason>> {
     val reasons = departureReasonRepository.findAll()
@@ -38,5 +43,11 @@ class ReferenceDataController(
     val destinationProviders = destinationProviderRepository.findAll()
 
     return ResponseEntity.ok(destinationProviders.map(destinationProviderTransformer::transformJpaToApi))
+  }
+
+  override fun referenceDataCancellationReasonsGet(): ResponseEntity<List<CancellationReason>> {
+    val cancellationReasons = cancellationReasonRepository.findAll()
+
+    return ResponseEntity.ok(cancellationReasons.map(cancellationReasonTransformer::transformJpaToApi))
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CancellationReasonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CancellationReasonEntity.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.Table
+
+@Repository
+interface CancellationReasonRepository : JpaRepository<CancellationReasonEntity, UUID>
+
+@Entity
+@Table(name = "cancellation_reasons")
+data class CancellationReasonEntity(
+  @Id
+  val id: UUID,
+  val name: String,
+  val isActive: Boolean
+) {
+  override fun toString() = "CancellationReasonEntity:$id"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/CancellationReasonTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/CancellationReasonTransformer.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.CancellationReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonEntity
+
+@Component
+class CancellationReasonTransformer() {
+  fun transformJpaToApi(jpa: CancellationReasonEntity) = CancellationReason(
+    id = jpa.id,
+    name = jpa.name,
+    isActive = jpa.isActive
+  )
+}

--- a/src/main/resources/db/migration/20220816105005__create_cancellation_reason.sql
+++ b/src/main/resources/db/migration/20220816105005__create_cancellation_reason.sql
@@ -1,0 +1,7 @@
+CREATE TABLE cancellation_reasons (
+    id UUID NOT NULL,
+    name TEXT NOT NULL,
+    is_active BOOL NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE (name)
+);

--- a/src/main/resources/static/mini-manage-api-stubs.yml
+++ b/src/main/resources/static/mini-manage-api-stubs.yml
@@ -534,6 +534,26 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /reference-data/cancellation-reasons:
+    get:
+      tags:
+        - Reference Data
+      summary: Lists all cancellation reasons
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CancellationReason'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
 components:
   responses:
     401Response:
@@ -992,6 +1012,21 @@ components:
         name:
           type: string
           example: Double Room with Single Occupancy - Other (Non-FM)
+        isActive:
+          type: boolean
+      required:
+        - id
+        - name
+        - isActive
+    CancellationReason:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Recall
         isActive:
           type: boolean
       required:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CancellationReasonEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CancellationReasonEntityFactory.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.CancellationReasonTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.util.UUID
+
+class CancellationReasonEntityFactory(
+  cancellationReasonTestRepository: CancellationReasonTestRepository
+) : PersistedFactory<CancellationReasonEntity, UUID>(cancellationReasonTestRepository) {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+  private var isActive: Yielded<Boolean> = { true }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withName(name: String) = apply {
+    this.name = { name }
+  }
+
+  fun withIsActive(isActive: Boolean) = apply {
+    this.isActive = { isActive }
+  }
+
+  override fun produce(): CancellationReasonEntity = CancellationReasonEntity(
+    id = this.id(),
+    name = this.name(),
+    isActive = this.isActive()
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFact
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ArrivalEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DestinationProviderEntityFactory
@@ -24,6 +25,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApAreaTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ArrivalTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.CancellationReasonTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.CancellationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DepartureReasonTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DepartureTestRepository
@@ -92,6 +94,9 @@ abstract class IntegrationTestBase {
   @Autowired
   lateinit var moveOnCategoryRepository: MoveOnCategoryTestRepository
 
+  @Autowired
+  lateinit var cancellationReasonRepository: CancellationReasonTestRepository
+
   lateinit var probationRegionEntityFactory: ProbationRegionEntityFactory
   lateinit var apAreaEntityFactory: ApAreaEntityFactory
   lateinit var localAuthorityEntityFactory: LocalAuthorityEntityFactory
@@ -105,6 +110,7 @@ abstract class IntegrationTestBase {
   lateinit var moveOnCategoryEntityFactory: MoveOnCategoryEntityFactory
   lateinit var nonArrivalEntityFactory: NonArrivalEntityFactory
   lateinit var cancellationEntityFactory: CancellationEntityFactory
+  lateinit var cancellationReasonEntityFactory: CancellationReasonEntityFactory
 
   @BeforeEach
   fun beforeEach() {
@@ -127,5 +133,6 @@ abstract class IntegrationTestBase {
     moveOnCategoryEntityFactory = MoveOnCategoryEntityFactory(moveOnCategoryRepository)
     nonArrivalEntityFactory = NonArrivalEntityFactory(nonArrivalRepository)
     cancellationEntityFactory = CancellationEntityFactory(cancellationRepository)
+    cancellationReasonEntityFactory = CancellationReasonEntityFactory(cancellationReasonRepository)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CancellationReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DepartureReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DestinationProviderTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.MoveOnCategoryTransformer
@@ -15,6 +16,9 @@ class ReferenceDataTest : IntegrationTestBase() {
 
   @Autowired
   lateinit var destinationProviderTransformer: DestinationProviderTransformer
+
+  @Autowired
+  lateinit var cancellationReasonTransformer: CancellationReasonTransformer
 
   @Test
   fun `Get Departure Reasons returns 200 with correct body`() {
@@ -71,6 +75,27 @@ class ReferenceDataTest : IntegrationTestBase() {
 
     webTestClient.get()
       .uri("/reference-data/destination-providers")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .json(expectedJson)
+  }
+
+  @Test
+  fun `Get Cancellation Reasons returns 200 with correct body`() {
+    cancellationReasonRepository.deleteAll()
+
+    val departureReasons = cancellationReasonEntityFactory.produceAndPersistMultiple(10)
+    val expectedJson = objectMapper.writeValueAsString(
+      departureReasons.map(cancellationReasonTransformer::transformJpaToApi)
+    )
+
+    val jwt = jwtAuthHelper.createValidJwt()
+
+    webTestClient.get()
+      .uri("/reference-data/cancellation-reasons")
       .header("Authorization", "Bearer $jwt")
       .exchange()
       .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/CancellationReasonTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/CancellationReasonTestRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonEntity
+import java.util.UUID
+
+@Repository
+interface CancellationReasonTestRepository : JpaRepository<CancellationReasonEntity, UUID>


### PR DESCRIPTION
This adds an API endpoint for Cancellation Reasons, following the pattern we already have for reference data. My first Kotlin PR, so be kind! 😄 