### PR TITLE
Use kfactories in unit tests

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApAreaEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApAreaEntityFactory.kt
@@ -8,8 +8,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCa
 import java.util.UUID
 
 class ApAreaEntityFactory(
-  apAreaTestRepository: ApAreaTestRepository
+  apAreaTestRepository: ApAreaTestRepository?
 ) : PersistedFactory<ApAreaEntity, UUID>(apAreaTestRepository) {
+  constructor() : this(null)
+
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
   private var identifier: Yielded<String> = { randomStringUpperCase(3) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ArrivalEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ArrivalEntityFactory.kt
@@ -11,8 +11,10 @@ import java.time.LocalDate
 import java.util.UUID
 
 class ArrivalEntityFactory(
-  arrivalTestRepository: ArrivalTestRepository
+  arrivalTestRepository: ArrivalTestRepository?
 ) : PersistedFactory<ArrivalEntity, UUID>(arrivalTestRepository) {
+  constructor() : this(null)
+
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var arrivalDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore() }
   private var expectedDepartureDate: Yielded<LocalDate> = { LocalDate.now().randomDateAfter() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
@@ -17,8 +17,10 @@ import java.util.UUID
 import kotlin.RuntimeException
 
 class BookingEntityFactory(
-  bookingTestRepository: BookingTestRepository
+  bookingTestRepository: BookingTestRepository?
 ) : PersistedFactory<BookingEntity, UUID>(bookingTestRepository) {
+  constructor() : this(null)
+
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var crn: Yielded<String> = { randomStringUpperCase(6) }
   private var arrivalDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CancellationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CancellationEntityFactory.kt
@@ -11,8 +11,10 @@ import java.time.LocalDate
 import java.util.UUID
 
 class CancellationEntityFactory(
-  cancellationTestRepository: CancellationTestRepository
+  cancellationTestRepository: CancellationTestRepository?
 ) : PersistedFactory<CancellationEntity, UUID>(cancellationTestRepository) {
+  constructor() : this(null)
+
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var date: Yielded<LocalDate> = { LocalDate.now().randomDateBefore() }
   private var reason: Yielded<String> = { randomStringUpperCase(8) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CancellationReasonEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CancellationReasonEntityFactory.kt
@@ -7,8 +7,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCa
 import java.util.UUID
 
 class CancellationReasonEntityFactory(
-  cancellationReasonTestRepository: CancellationReasonTestRepository
+  cancellationReasonTestRepository: CancellationReasonTestRepository?
 ) : PersistedFactory<CancellationReasonEntity, UUID>(cancellationReasonTestRepository) {
+  constructor() : this(null)
+
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
   private var isActive: Yielded<Boolean> = { true }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DepartureEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DepartureEntityFactory.kt
@@ -13,8 +13,10 @@ import java.time.OffsetDateTime
 import java.util.UUID
 
 class DepartureEntityFactory(
-  departureTestRepository: DepartureTestRepository
+  departureTestRepository: DepartureTestRepository?
 ) : PersistedFactory<DepartureEntity, UUID>(departureTestRepository) {
+  constructor() : this(null)
+
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var dateTime: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeAfter() }
   private var reason: Yielded<DepartureReasonEntity>? = null

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DepartureReasonEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DepartureReasonEntityFactory.kt
@@ -7,8 +7,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCa
 import java.util.UUID
 
 class DepartureReasonEntityFactory(
-  departureReasonTestRepository: DepartureReasonTestRepository
+  departureReasonTestRepository: DepartureReasonTestRepository?
 ) : PersistedFactory<DepartureReasonEntity, UUID>(departureReasonTestRepository) {
+  constructor() : this(null)
+
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
   private var isActive: Yielded<Boolean> = { true }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DestinationProviderEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DestinationProviderEntityFactory.kt
@@ -7,8 +7,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCa
 import java.util.UUID
 
 class DestinationProviderEntityFactory(
-  destinationProviderTestRepository: DestinationProviderTestRepository
+  destinationProviderTestRepository: DestinationProviderTestRepository?
 ) : PersistedFactory<DestinationProviderEntity, UUID>(destinationProviderTestRepository) {
+  constructor() : this(null)
+
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
   private var isActive: Yielded<Boolean> = { true }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/KeyWorkerEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/KeyWorkerEntityFactory.kt
@@ -7,8 +7,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCa
 import java.util.UUID
 
 class KeyWorkerEntityFactory(
-  keyWorkerTestRepository: KeyWorkerTestRepository
+  keyWorkerTestRepository: KeyWorkerTestRepository?
 ) : PersistedFactory<KeyWorkerEntity, UUID>(keyWorkerTestRepository) {
+  constructor() : this(null)
+
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringUpperCase(12) }
   private var isActive: Yielded<Boolean> = { true }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/LocalAuthorityEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/LocalAuthorityEntityFactory.kt
@@ -8,8 +8,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCa
 import java.util.UUID
 
 class LocalAuthorityEntityFactory(
-  localAuthorityAreaTestRepository: LocalAuthorityAreaTestRepository
+  localAuthorityAreaTestRepository: LocalAuthorityAreaTestRepository?
 ) : PersistedFactory<LocalAuthorityAreaEntity, UUID>(localAuthorityAreaTestRepository) {
+  constructor() : this(null)
+
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var identifier: Yielded<String> = { randomStringUpperCase(5) }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/LostBedsEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/LostBedsEntityFactory.kt
@@ -13,8 +13,10 @@ import java.time.LocalDate
 import java.util.UUID
 
 class LostBedsEntityFactory(
-  lostBedsTestRepository: LostBedsTestRepository
+  lostBedsTestRepository: LostBedsTestRepository?
 ) : PersistedFactory<LostBedsEntity, UUID>(lostBedsTestRepository) {
+  constructor() : this(null)
+
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var startDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore(6) }
   private var endDate: Yielded<LocalDate> = { LocalDate.now().randomDateAfter(6) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/MoveOnCategoryEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/MoveOnCategoryEntityFactory.kt
@@ -7,8 +7,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCa
 import java.util.UUID
 
 class MoveOnCategoryEntityFactory(
-  moveOnCategoryTestRepository: MoveOnCategoryTestRepository
+  moveOnCategoryTestRepository: MoveOnCategoryTestRepository?
 ) : PersistedFactory<MoveOnCategoryEntity, UUID>(moveOnCategoryTestRepository) {
+  constructor() : this(null)
+
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
   private var isActive: Yielded<Boolean> = { true }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/NonArrivalEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/NonArrivalEntityFactory.kt
@@ -10,8 +10,10 @@ import java.time.LocalDate
 import java.util.UUID
 
 class NonArrivalEntityFactory(
-  nonArrivalTestRepository: NonArrivalTestRepository
+  nonArrivalTestRepository: NonArrivalTestRepository?
 ) : PersistedFactory<NonArrivalEntity, UUID>(nonArrivalTestRepository) {
+  constructor() : this(null)
+
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var date: Yielded<LocalDate> = { LocalDate.now().randomDateBefore() }
   private var reason: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PersistedFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PersistedFactory.kt
@@ -3,7 +3,9 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 import io.github.bluegroundltd.kfactory.Factory
 import org.springframework.data.jpa.repository.JpaRepository
 
-abstract class PersistedFactory<EntityType : Any, PrimaryKeyType : Any>(private val repository: JpaRepository<EntityType, PrimaryKeyType>) : Factory<EntityType> {
-  fun produceAndPersist(): EntityType = repository.saveAndFlush(this.produce())
+abstract class PersistedFactory<EntityType : Any, PrimaryKeyType : Any>(private val repository: JpaRepository<EntityType, PrimaryKeyType>?) : Factory<EntityType> {
+  constructor() : this(null)
+
+  fun produceAndPersist(): EntityType = repository?.saveAndFlush(this.produce()) ?: throw RuntimeException("Cannot persist because no repository was provided.  If this is a unit test did you mean to call .produce() instead?")
   fun produceAndPersistMultiple(amount: Int) = (1..amount).map { produceAndPersist() }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PremisesEntityFactory.kt
@@ -13,8 +13,10 @@ import java.lang.RuntimeException
 import java.util.UUID
 
 class PremisesEntityFactory(
-  premisesTestRepository: PremisesTestRepository
+  premisesTestRepository: PremisesTestRepository?
 ) : PersistedFactory<PremisesEntity, UUID>(premisesTestRepository) {
+  constructor() : this(null)
+
   private var probationRegion: Yielded<ProbationRegionEntity>? = null
   private var localAuthorityArea: Yielded<LocalAuthorityAreaEntity>? = null
   private var id: Yielded<UUID> = { UUID.randomUUID() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ProbationRegionEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ProbationRegionEntityFactory.kt
@@ -8,8 +8,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCa
 import java.util.UUID
 
 class ProbationRegionEntityFactory(
-  probationRegionTestRepository: ProbationRegionTestRepository
+  probationRegionTestRepository: ProbationRegionTestRepository?
 ) : PersistedFactory<ProbationRegionEntity, UUID>(probationRegionTestRepository) {
+  constructor() : this(null)
+
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
   private var apArea: Yielded<ApAreaEntity>? = null


### PR DESCRIPTION
Changes to allow us to use the existing factories in unit tests by not providing a repository - i.e. just produce the object rather than also saving it to JPA.