### PR TITLE
Changes to allow using existing kfactories in both integration and unit tests.

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApAreaEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApAreaEntityFactory.kt
@@ -1,15 +1,13 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
+import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApAreaTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
 import java.util.UUID
 
-class ApAreaEntityFactory(
-  apAreaTestRepository: ApAreaTestRepository
-) : PersistedFactory<ApAreaEntity, UUID>(apAreaTestRepository) {
+class ApAreaEntityFactory : Factory<ApAreaEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
   private var identifier: Yielded<String> = { randomStringUpperCase(3) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ArrivalEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ArrivalEntityFactory.kt
@@ -1,18 +1,16 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
+import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ArrivalTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.LocalDate
 import java.util.UUID
 
-class ArrivalEntityFactory(
-  arrivalTestRepository: ArrivalTestRepository
-) : PersistedFactory<ArrivalEntity, UUID>(arrivalTestRepository) {
+class ArrivalEntityFactory : Factory<ArrivalEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var arrivalDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore() }
   private var expectedDepartureDate: Yielded<LocalDate> = { LocalDate.now().randomDateAfter() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
+import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
@@ -8,7 +9,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureEnti
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.KeyWorkerEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
@@ -16,9 +16,7 @@ import java.time.LocalDate
 import java.util.UUID
 import kotlin.RuntimeException
 
-class BookingEntityFactory(
-  bookingTestRepository: BookingTestRepository
-) : PersistedFactory<BookingEntity, UUID>(bookingTestRepository) {
+class BookingEntityFactory : Factory<BookingEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var crn: Yielded<String> = { randomStringUpperCase(6) }
   private var arrivalDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CancellationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CancellationEntityFactory.kt
@@ -1,18 +1,16 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
+import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.CancellationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
 import java.time.LocalDate
 import java.util.UUID
 
-class CancellationEntityFactory(
-  cancellationTestRepository: CancellationTestRepository
-) : PersistedFactory<CancellationEntity, UUID>(cancellationTestRepository) {
+class CancellationEntityFactory : Factory<CancellationEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var date: Yielded<LocalDate> = { LocalDate.now().randomDateBefore() }
   private var reason: Yielded<String> = { randomStringUpperCase(8) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CancellationReasonEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CancellationReasonEntityFactory.kt
@@ -1,14 +1,12 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
+import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.CancellationReasonTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.util.UUID
 
-class CancellationReasonEntityFactory(
-  cancellationReasonTestRepository: CancellationReasonTestRepository
-) : PersistedFactory<CancellationReasonEntity, UUID>(cancellationReasonTestRepository) {
+class CancellationReasonEntityFactory : Factory<CancellationReasonEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
   private var isActive: Yielded<Boolean> = { true }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DepartureEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DepartureEntityFactory.kt
@@ -1,20 +1,18 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
+import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DestinationProviderEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DepartureTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeAfter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.OffsetDateTime
 import java.util.UUID
 
-class DepartureEntityFactory(
-  departureTestRepository: DepartureTestRepository
-) : PersistedFactory<DepartureEntity, UUID>(departureTestRepository) {
+class DepartureEntityFactory : Factory<DepartureEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var dateTime: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeAfter() }
   private var reason: Yielded<DepartureReasonEntity>? = null

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DepartureReasonEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DepartureReasonEntityFactory.kt
@@ -1,14 +1,12 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
+import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DepartureReasonTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.util.UUID
 
-class DepartureReasonEntityFactory(
-  departureReasonTestRepository: DepartureReasonTestRepository
-) : PersistedFactory<DepartureReasonEntity, UUID>(departureReasonTestRepository) {
+class DepartureReasonEntityFactory : Factory<DepartureReasonEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
   private var isActive: Yielded<Boolean> = { true }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DestinationProviderEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DestinationProviderEntityFactory.kt
@@ -1,14 +1,12 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
+import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DestinationProviderEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DestinationProviderTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.util.UUID
 
-class DestinationProviderEntityFactory(
-  destinationProviderTestRepository: DestinationProviderTestRepository
-) : PersistedFactory<DestinationProviderEntity, UUID>(destinationProviderTestRepository) {
+class DestinationProviderEntityFactory : Factory<DestinationProviderEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
   private var isActive: Yielded<Boolean> = { true }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/KeyWorkerEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/KeyWorkerEntityFactory.kt
@@ -1,14 +1,12 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
+import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.KeyWorkerEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.KeyWorkerTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
 import java.util.UUID
 
-class KeyWorkerEntityFactory(
-  keyWorkerTestRepository: KeyWorkerTestRepository
-) : PersistedFactory<KeyWorkerEntity, UUID>(keyWorkerTestRepository) {
+class KeyWorkerEntityFactory : Factory<KeyWorkerEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringUpperCase(12) }
   private var isActive: Yielded<Boolean> = { true }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/LocalAuthorityEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/LocalAuthorityEntityFactory.kt
@@ -1,15 +1,13 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
+import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.LocalAuthorityAreaTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
 import java.util.UUID
 
-class LocalAuthorityEntityFactory(
-  localAuthorityAreaTestRepository: LocalAuthorityAreaTestRepository
-) : PersistedFactory<LocalAuthorityAreaEntity, UUID>(localAuthorityAreaTestRepository) {
+class LocalAuthorityEntityFactory : Factory<LocalAuthorityAreaEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var identifier: Yielded<String> = { randomStringUpperCase(5) }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/LostBedsEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/LostBedsEntityFactory.kt
@@ -1,10 +1,10 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
+import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.LostBedsTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
@@ -12,9 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCa
 import java.time.LocalDate
 import java.util.UUID
 
-class LostBedsEntityFactory(
-  lostBedsTestRepository: LostBedsTestRepository
-) : PersistedFactory<LostBedsEntity, UUID>(lostBedsTestRepository) {
+class LostBedsEntityFactory : Factory<LostBedsEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var startDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore(6) }
   private var endDate: Yielded<LocalDate> = { LocalDate.now().randomDateAfter(6) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/MoveOnCategoryEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/MoveOnCategoryEntityFactory.kt
@@ -1,14 +1,12 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
+import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.MoveOnCategoryTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.util.UUID
 
-class MoveOnCategoryEntityFactory(
-  moveOnCategoryTestRepository: MoveOnCategoryTestRepository
-) : PersistedFactory<MoveOnCategoryEntity, UUID>(moveOnCategoryTestRepository) {
+class MoveOnCategoryEntityFactory : Factory<MoveOnCategoryEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
   private var isActive: Yielded<Boolean> = { true }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/NonArrivalEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/NonArrivalEntityFactory.kt
@@ -1,17 +1,15 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
+import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.NonArrivalTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.LocalDate
 import java.util.UUID
 
-class NonArrivalEntityFactory(
-  nonArrivalTestRepository: NonArrivalTestRepository
-) : PersistedFactory<NonArrivalEntity, UUID>(nonArrivalTestRepository) {
+class NonArrivalEntityFactory : Factory<NonArrivalEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var date: Yielded<LocalDate> = { LocalDate.now().randomDateBefore() }
   private var reason: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PersistedFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PersistedFactory.kt
@@ -4,7 +4,15 @@ import io.github.bluegroundltd.kfactory.Factory
 import org.springframework.data.jpa.repository.JpaRepository
 
 class PersistedFactory<EntityType : Any, PrimaryKeyType : Any, FactoryType : Factory<EntityType>>(private val factory: FactoryType, private val repository: JpaRepository<EntityType, PrimaryKeyType>) {
-  fun configure(block: FactoryType.() -> Unit) = apply { block(factory) }
   fun produceAndPersist(): EntityType = repository.saveAndFlush(factory.produce())
+  fun produceAndPersist(configuration: FactoryType.() -> Unit): EntityType {
+    configuration(factory)
+    return repository.saveAndFlush(factory.produce())
+  }
+
   fun produceAndPersistMultiple(amount: Int) = (1..amount).map { produceAndPersist() }
+  fun produceAndPersistMultiple(amount: Int, configuration: FactoryType.() -> Unit): List<EntityType> {
+    configuration(factory)
+    return (1..amount).map { produceAndPersist() }
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PersistedFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PersistedFactory.kt
@@ -3,7 +3,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 import io.github.bluegroundltd.kfactory.Factory
 import org.springframework.data.jpa.repository.JpaRepository
 
-abstract class PersistedFactory<EntityType : Any, PrimaryKeyType : Any>(private val repository: JpaRepository<EntityType, PrimaryKeyType>) : Factory<EntityType> {
-  fun produceAndPersist(): EntityType = repository.saveAndFlush(this.produce())
+class PersistedFactory<EntityType : Any, PrimaryKeyType : Any, FactoryType : Factory<EntityType>>(private val factory: FactoryType, private val repository: JpaRepository<EntityType, PrimaryKeyType>) {
+  fun configure(block: FactoryType.() -> Unit) = apply { block(factory) }
+  fun produceAndPersist(): EntityType = repository.saveAndFlush(factory.produce())
   fun produceAndPersistMultiple(amount: Int) = (1..amount).map { produceAndPersist() }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PremisesEntityFactory.kt
@@ -1,20 +1,17 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
+import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.PremisesTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomPostCode
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
-import java.lang.RuntimeException
 import java.util.UUID
 
-class PremisesEntityFactory(
-  premisesTestRepository: PremisesTestRepository
-) : PersistedFactory<PremisesEntity, UUID>(premisesTestRepository) {
+class PremisesEntityFactory : Factory<PremisesEntity> {
   private var probationRegion: Yielded<ProbationRegionEntity>? = null
   private var localAuthorityArea: Yielded<LocalAuthorityAreaEntity>? = null
   private var id: Yielded<UUID> = { UUID.randomUUID() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ProbationRegionEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ProbationRegionEntityFactory.kt
@@ -1,15 +1,13 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
+import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ProbationRegionTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.util.UUID
 
-class ProbationRegionEntityFactory(
-  probationRegionTestRepository: ProbationRegionTestRepository
-) : PersistedFactory<ProbationRegionEntity, UUID>(probationRegionTestRepository) {
+class ProbationRegionEntityFactory : Factory<ProbationRegionEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
   private var apArea: Yielded<ApAreaEntity>? = null

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -37,10 +37,10 @@ class BookingTest : IntegrationTestBase() {
 
   @Test
   fun `Get all Bookings on Premises without any Bookings returns empty list`() {
-    val premises = premisesEntityFactory
-      .withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      .withYieldedProbationRegion { probationRegionEntityFactory.withYieldedApArea { apAreaEntityFactory.produceAndPersist() }.produceAndPersist() }
-      .produceAndPersist()
+    val premises = premisesEntityFactory.configure {
+      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+      withYieldedProbationRegion { probationRegionEntityFactory.configure { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }.produceAndPersist() }
+    }.produceAndPersist()
 
     val jwt = jwtAuthHelper.createValidJwt()
 
@@ -56,28 +56,30 @@ class BookingTest : IntegrationTestBase() {
 
   @Test
   fun `Get all Bookings returns OK with correct body`() {
-    val premises = premisesEntityFactory
-      .withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      .withYieldedProbationRegion { probationRegionEntityFactory.withYieldedApArea { apAreaEntityFactory.produceAndPersist() }.produceAndPersist() }
-      .produceAndPersist()
+    val premises = premisesEntityFactory.configure {
+      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.configure { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }.produceAndPersist()
+      }
+    }.produceAndPersist()
 
-    val bookings = bookingEntityFactory
-      .withPremises(premises)
-      .withYieldedKeyWorker { keyWorkerEntityFactory.produceAndPersist() }
-      .produceAndPersistMultiple(5)
+    val bookings = bookingEntityFactory.configure {
+      withPremises(premises)
+      withYieldedKeyWorker { keyWorkerEntityFactory.produceAndPersist() }
+    }.produceAndPersistMultiple(5)
 
-    bookings[1].let { it.arrival = arrivalEntityFactory.withBooking(it).produceAndPersist() }
+    bookings[1].let { it.arrival = arrivalEntityFactory.configure { withBooking(it) }.produceAndPersist() }
     bookings[2].let {
-      it.arrival = arrivalEntityFactory.withBooking(it).produceAndPersist()
-      it.departure = departureEntityFactory
-        .withBooking(it)
-        .withYieldedDestinationProvider { destinationProviderEntityFactory.produceAndPersist() }
-        .withYieldedReason { departureReasonEntityFactory.produceAndPersist() }
-        .withYieldedMoveOnCategory { moveOnCategoryEntityFactory.produceAndPersist() }
-        .produceAndPersist()
+      it.arrival = arrivalEntityFactory.configure { withBooking(it) }.produceAndPersist()
+      it.departure = departureEntityFactory.configure {
+        withBooking(it)
+        withYieldedDestinationProvider { destinationProviderEntityFactory.produceAndPersist() }
+        withYieldedReason { departureReasonEntityFactory.produceAndPersist() }
+        withYieldedMoveOnCategory { moveOnCategoryEntityFactory.produceAndPersist() }
+      }.produceAndPersist()
     }
-    bookings[3].let { it.cancellation = cancellationEntityFactory.withBooking(it).produceAndPersist() }
-    bookings[4].let { it.nonArrival = nonArrivalEntityFactory.withBooking(it).produceAndPersist() }
+    bookings[3].let { it.cancellation = cancellationEntityFactory.configure { withBooking(it) }.produceAndPersist() }
+    bookings[4].let { it.nonArrival = nonArrivalEntityFactory.configure { withBooking(it) }.produceAndPersist() }
 
     val expectedJson = objectMapper.writeValueAsString(
       bookings.map {
@@ -100,10 +102,12 @@ class BookingTest : IntegrationTestBase() {
 
   @Test
   fun `Create Booking without JWT returns 401`() {
-    val premises = premisesEntityFactory
-      .withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      .withYieldedProbationRegion { probationRegionEntityFactory.withYieldedApArea { apAreaEntityFactory.produceAndPersist() }.produceAndPersist() }
-      .produceAndPersist()
+    val premises = premisesEntityFactory.configure {
+      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.configure { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }.produceAndPersist()
+      }
+    }.produceAndPersist()
 
     val keyWorker = keyWorkerEntityFactory.produceAndPersist()
 
@@ -146,10 +150,12 @@ class BookingTest : IntegrationTestBase() {
 
   @Test
   fun `Create booking with non existent Key Worker returns Bad Request with correct body`() {
-    val premises = premisesEntityFactory
-      .withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      .withYieldedProbationRegion { probationRegionEntityFactory.withYieldedApArea { apAreaEntityFactory.produceAndPersist() }.produceAndPersist() }
-      .produceAndPersist()
+    val premises = premisesEntityFactory.configure {
+      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.configure { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }.produceAndPersist()
+      }
+    }.produceAndPersist()
 
     val jwt = jwtAuthHelper.createValidJwt()
 
@@ -178,10 +184,12 @@ class BookingTest : IntegrationTestBase() {
 
   @Test
   fun `Create Booking returns OK with correct body`() {
-    val premises = premisesEntityFactory
-      .withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      .withYieldedProbationRegion { probationRegionEntityFactory.withYieldedApArea { apAreaEntityFactory.produceAndPersist() }.produceAndPersist() }
-      .produceAndPersist()
+    val premises = premisesEntityFactory.configure {
+      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.configure { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }.produceAndPersist()
+      }
+    }.produceAndPersist()
 
     val keyWorker = keyWorkerEntityFactory.produceAndPersist()
 
@@ -252,16 +260,19 @@ class BookingTest : IntegrationTestBase() {
 
   @Test
   fun `Create Arrival on Booking with existing Arrival returns 400`() {
-    val booking = bookingEntityFactory
-      .withYieldedKeyWorker { keyWorkerEntityFactory.produceAndPersist() }
-      .withYieldedPremises {
-        premisesEntityFactory
-          .withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          .withYieldedProbationRegion { probationRegionEntityFactory.withYieldedApArea { apAreaEntityFactory.produceAndPersist() }.produceAndPersist() }
-          .produceAndPersist()
-      }.produceAndPersist()
+    val booking = bookingEntityFactory.configure {
+      withYieldedKeyWorker { keyWorkerEntityFactory.produceAndPersist() }
+      withYieldedPremises {
+        premisesEntityFactory.configure {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.configure { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }.produceAndPersist()
+          }
+        }.produceAndPersist()
+      }
+    }.produceAndPersist()
 
-    arrivalEntityFactory.withBooking(booking).produceAndPersist()
+    arrivalEntityFactory.configure { withBooking(booking) }.produceAndPersist()
 
     val jwt = jwtAuthHelper.createValidJwt()
 
@@ -284,14 +295,19 @@ class BookingTest : IntegrationTestBase() {
 
   @Test
   fun `Create Arrival on Booking with expected departure before arrival date returns 400`() {
-    val booking = bookingEntityFactory
-      .withYieldedKeyWorker { keyWorkerEntityFactory.produceAndPersist() }
-      .withYieldedPremises {
-        premisesEntityFactory
-          .withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          .withYieldedProbationRegion { probationRegionEntityFactory.withYieldedApArea { apAreaEntityFactory.produceAndPersist() }.produceAndPersist() }
-          .produceAndPersist()
-      }.produceAndPersist()
+    val booking = bookingEntityFactory.configure {
+      withYieldedKeyWorker { keyWorkerEntityFactory.produceAndPersist() }
+      withYieldedPremises {
+        premisesEntityFactory.configure {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.configure {
+              withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+            }.produceAndPersist()
+          }
+        }.produceAndPersist()
+      }
+    }.produceAndPersist()
 
     val jwt = jwtAuthHelper.createValidJwt()
 
@@ -319,14 +335,19 @@ class BookingTest : IntegrationTestBase() {
 
   @Test
   fun `Create Arrival on Booking returns 200 with correct body`() {
-    val booking = bookingEntityFactory
-      .withYieldedKeyWorker { keyWorkerEntityFactory.produceAndPersist() }
-      .withYieldedPremises {
-        premisesEntityFactory
-          .withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          .withYieldedProbationRegion { probationRegionEntityFactory.withYieldedApArea { apAreaEntityFactory.produceAndPersist() }.produceAndPersist() }
-          .produceAndPersist()
-      }.produceAndPersist()
+    val booking = bookingEntityFactory.configure {
+      withYieldedKeyWorker { keyWorkerEntityFactory.produceAndPersist() }
+      withYieldedPremises {
+        premisesEntityFactory.configure {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.configure {
+              withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+            }.produceAndPersist()
+          }
+        }.produceAndPersist()
+      }
+    }.produceAndPersist()
 
     val jwt = jwtAuthHelper.createValidJwt()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -37,10 +37,10 @@ class BookingTest : IntegrationTestBase() {
 
   @Test
   fun `Get all Bookings on Premises without any Bookings returns empty list`() {
-    val premises = premisesEntityFactory.configure {
+    val premises = premisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion { probationRegionEntityFactory.configure { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }.produceAndPersist() }
-    }.produceAndPersist()
+      withYieldedProbationRegion { probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } } }
+    }
 
     val jwt = jwtAuthHelper.createValidJwt()
 
@@ -56,30 +56,30 @@ class BookingTest : IntegrationTestBase() {
 
   @Test
   fun `Get all Bookings returns OK with correct body`() {
-    val premises = premisesEntityFactory.configure {
+    val premises = premisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion {
-        probationRegionEntityFactory.configure { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }.produceAndPersist()
+        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
       }
-    }.produceAndPersist()
+    }
 
-    val bookings = bookingEntityFactory.configure {
+    val bookings = bookingEntityFactory.produceAndPersistMultiple(5) {
       withPremises(premises)
       withYieldedKeyWorker { keyWorkerEntityFactory.produceAndPersist() }
-    }.produceAndPersistMultiple(5)
+    }
 
-    bookings[1].let { it.arrival = arrivalEntityFactory.configure { withBooking(it) }.produceAndPersist() }
+    bookings[1].let { it.arrival = arrivalEntityFactory.produceAndPersist { withBooking(it) } }
     bookings[2].let {
-      it.arrival = arrivalEntityFactory.configure { withBooking(it) }.produceAndPersist()
-      it.departure = departureEntityFactory.configure {
+      it.arrival = arrivalEntityFactory.produceAndPersist { withBooking(it) }
+      it.departure = departureEntityFactory.produceAndPersist {
         withBooking(it)
         withYieldedDestinationProvider { destinationProviderEntityFactory.produceAndPersist() }
         withYieldedReason { departureReasonEntityFactory.produceAndPersist() }
         withYieldedMoveOnCategory { moveOnCategoryEntityFactory.produceAndPersist() }
-      }.produceAndPersist()
+      }
     }
-    bookings[3].let { it.cancellation = cancellationEntityFactory.configure { withBooking(it) }.produceAndPersist() }
-    bookings[4].let { it.nonArrival = nonArrivalEntityFactory.configure { withBooking(it) }.produceAndPersist() }
+    bookings[3].let { it.cancellation = cancellationEntityFactory.produceAndPersist { withBooking(it) } }
+    bookings[4].let { it.nonArrival = nonArrivalEntityFactory.produceAndPersist { withBooking(it) } }
 
     val expectedJson = objectMapper.writeValueAsString(
       bookings.map {
@@ -102,12 +102,12 @@ class BookingTest : IntegrationTestBase() {
 
   @Test
   fun `Create Booking without JWT returns 401`() {
-    val premises = premisesEntityFactory.configure {
+    val premises = premisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion {
-        probationRegionEntityFactory.configure { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }.produceAndPersist()
+        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
       }
-    }.produceAndPersist()
+    }
 
     val keyWorker = keyWorkerEntityFactory.produceAndPersist()
 
@@ -150,12 +150,12 @@ class BookingTest : IntegrationTestBase() {
 
   @Test
   fun `Create booking with non existent Key Worker returns Bad Request with correct body`() {
-    val premises = premisesEntityFactory.configure {
+    val premises = premisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion {
-        probationRegionEntityFactory.configure { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }.produceAndPersist()
+        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
       }
-    }.produceAndPersist()
+    }
 
     val jwt = jwtAuthHelper.createValidJwt()
 
@@ -184,12 +184,12 @@ class BookingTest : IntegrationTestBase() {
 
   @Test
   fun `Create Booking returns OK with correct body`() {
-    val premises = premisesEntityFactory.configure {
+    val premises = premisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion {
-        probationRegionEntityFactory.configure { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }.produceAndPersist()
+        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
       }
-    }.produceAndPersist()
+    }
 
     val keyWorker = keyWorkerEntityFactory.produceAndPersist()
 
@@ -260,19 +260,19 @@ class BookingTest : IntegrationTestBase() {
 
   @Test
   fun `Create Arrival on Booking with existing Arrival returns 400`() {
-    val booking = bookingEntityFactory.configure {
+    val booking = bookingEntityFactory.produceAndPersist {
       withYieldedKeyWorker { keyWorkerEntityFactory.produceAndPersist() }
       withYieldedPremises {
-        premisesEntityFactory.configure {
+        premisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
-            probationRegionEntityFactory.configure { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }.produceAndPersist()
+            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
           }
-        }.produceAndPersist()
+        }
       }
-    }.produceAndPersist()
+    }
 
-    arrivalEntityFactory.configure { withBooking(booking) }.produceAndPersist()
+    arrivalEntityFactory.produceAndPersist { withBooking(booking) }
 
     val jwt = jwtAuthHelper.createValidJwt()
 
@@ -295,19 +295,19 @@ class BookingTest : IntegrationTestBase() {
 
   @Test
   fun `Create Arrival on Booking with expected departure before arrival date returns 400`() {
-    val booking = bookingEntityFactory.configure {
+    val booking = bookingEntityFactory.produceAndPersist {
       withYieldedKeyWorker { keyWorkerEntityFactory.produceAndPersist() }
       withYieldedPremises {
-        premisesEntityFactory.configure {
+        premisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
-            probationRegionEntityFactory.configure {
+            probationRegionEntityFactory.produceAndPersist {
               withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-            }.produceAndPersist()
+            }
           }
-        }.produceAndPersist()
+        }
       }
-    }.produceAndPersist()
+    }
 
     val jwt = jwtAuthHelper.createValidJwt()
 
@@ -335,19 +335,19 @@ class BookingTest : IntegrationTestBase() {
 
   @Test
   fun `Create Arrival on Booking returns 200 with correct body`() {
-    val booking = bookingEntityFactory.configure {
+    val booking = bookingEntityFactory.produceAndPersist {
       withYieldedKeyWorker { keyWorkerEntityFactory.produceAndPersist() }
       withYieldedPremises {
-        premisesEntityFactory.configure {
+        premisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
-            probationRegionEntityFactory.configure {
+            probationRegionEntityFactory.produceAndPersist {
               withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-            }.produceAndPersist()
+            }
           }
-        }.produceAndPersist()
+        }
       }
-    }.produceAndPersist()
+    }
 
     val jwt = jwtAuthHelper.createValidJwt()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -20,8 +20,23 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.KeyWorkerEntityF
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.MoveOnCategoryEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersistedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ArrivalEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DestinationProviderEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.KeyWorkerEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApAreaTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ArrivalTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingTestRepository
@@ -37,6 +52,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.NonArrivalTes
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.PremisesTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ProbationRegionTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.JwtAuthHelper
+import java.util.UUID
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ActiveProfiles("test")
@@ -97,20 +113,20 @@ abstract class IntegrationTestBase {
   @Autowired
   lateinit var cancellationReasonRepository: CancellationReasonTestRepository
 
-  lateinit var probationRegionEntityFactory: ProbationRegionEntityFactory
-  lateinit var apAreaEntityFactory: ApAreaEntityFactory
-  lateinit var localAuthorityEntityFactory: LocalAuthorityEntityFactory
-  lateinit var premisesEntityFactory: PremisesEntityFactory
-  lateinit var bookingEntityFactory: BookingEntityFactory
-  lateinit var keyWorkerEntityFactory: KeyWorkerEntityFactory
-  lateinit var arrivalEntityFactory: ArrivalEntityFactory
-  lateinit var departureEntityFactory: DepartureEntityFactory
-  lateinit var destinationProviderEntityFactory: DestinationProviderEntityFactory
-  lateinit var departureReasonEntityFactory: DepartureReasonEntityFactory
-  lateinit var moveOnCategoryEntityFactory: MoveOnCategoryEntityFactory
-  lateinit var nonArrivalEntityFactory: NonArrivalEntityFactory
-  lateinit var cancellationEntityFactory: CancellationEntityFactory
-  lateinit var cancellationReasonEntityFactory: CancellationReasonEntityFactory
+  lateinit var probationRegionEntityFactory: PersistedFactory<ProbationRegionEntity, UUID, ProbationRegionEntityFactory>
+  lateinit var apAreaEntityFactory: PersistedFactory<ApAreaEntity, UUID, ApAreaEntityFactory>
+  lateinit var localAuthorityEntityFactory: PersistedFactory<LocalAuthorityAreaEntity, UUID, LocalAuthorityEntityFactory>
+  lateinit var premisesEntityFactory: PersistedFactory<PremisesEntity, UUID, PremisesEntityFactory>
+  lateinit var bookingEntityFactory: PersistedFactory<BookingEntity, UUID, BookingEntityFactory>
+  lateinit var keyWorkerEntityFactory: PersistedFactory<KeyWorkerEntity, UUID, KeyWorkerEntityFactory>
+  lateinit var arrivalEntityFactory: PersistedFactory<ArrivalEntity, UUID, ArrivalEntityFactory>
+  lateinit var departureEntityFactory: PersistedFactory<DepartureEntity, UUID, DepartureEntityFactory>
+  lateinit var destinationProviderEntityFactory: PersistedFactory<DestinationProviderEntity, UUID, DestinationProviderEntityFactory>
+  lateinit var departureReasonEntityFactory: PersistedFactory<DepartureReasonEntity, UUID, DepartureReasonEntityFactory>
+  lateinit var moveOnCategoryEntityFactory: PersistedFactory<MoveOnCategoryEntity, UUID, MoveOnCategoryEntityFactory>
+  lateinit var nonArrivalEntityFactory: PersistedFactory<NonArrivalEntity, UUID, NonArrivalEntityFactory>
+  lateinit var cancellationEntityFactory: PersistedFactory<CancellationEntity, UUID, CancellationEntityFactory>
+  lateinit var cancellationReasonEntityFactory: PersistedFactory<CancellationReasonEntity, UUID, CancellationReasonEntityFactory>
 
   @BeforeEach
   fun beforeEach() {
@@ -120,19 +136,19 @@ abstract class IntegrationTestBase {
 
   @BeforeEach
   fun setupFactories() {
-    probationRegionEntityFactory = ProbationRegionEntityFactory(probationRegionRepository)
-    apAreaEntityFactory = ApAreaEntityFactory(apAreaRepository)
-    localAuthorityEntityFactory = LocalAuthorityEntityFactory(localAuthorityAreaRepository)
-    premisesEntityFactory = PremisesEntityFactory(premisesRepository)
-    bookingEntityFactory = BookingEntityFactory(bookingRepository)
-    keyWorkerEntityFactory = KeyWorkerEntityFactory(keyWorkerRepository)
-    arrivalEntityFactory = ArrivalEntityFactory(arrivalRepository)
-    departureEntityFactory = DepartureEntityFactory(departureRepository)
-    destinationProviderEntityFactory = DestinationProviderEntityFactory(destinationProviderRepository)
-    departureReasonEntityFactory = DepartureReasonEntityFactory(departureReasonRepository)
-    moveOnCategoryEntityFactory = MoveOnCategoryEntityFactory(moveOnCategoryRepository)
-    nonArrivalEntityFactory = NonArrivalEntityFactory(nonArrivalRepository)
-    cancellationEntityFactory = CancellationEntityFactory(cancellationRepository)
-    cancellationReasonEntityFactory = CancellationReasonEntityFactory(cancellationReasonRepository)
+    probationRegionEntityFactory = PersistedFactory(ProbationRegionEntityFactory(), probationRegionRepository)
+    apAreaEntityFactory = PersistedFactory(ApAreaEntityFactory(), apAreaRepository)
+    localAuthorityEntityFactory = PersistedFactory(LocalAuthorityEntityFactory(), localAuthorityAreaRepository)
+    premisesEntityFactory = PersistedFactory(PremisesEntityFactory(), premisesRepository)
+    bookingEntityFactory = PersistedFactory(BookingEntityFactory(), bookingRepository)
+    keyWorkerEntityFactory = PersistedFactory(KeyWorkerEntityFactory(), keyWorkerRepository)
+    arrivalEntityFactory = PersistedFactory(ArrivalEntityFactory(), arrivalRepository)
+    departureEntityFactory = PersistedFactory(DepartureEntityFactory(), departureRepository)
+    destinationProviderEntityFactory = PersistedFactory(DestinationProviderEntityFactory(), destinationProviderRepository)
+    departureReasonEntityFactory = PersistedFactory(DepartureReasonEntityFactory(), departureReasonRepository)
+    moveOnCategoryEntityFactory = PersistedFactory(MoveOnCategoryEntityFactory(), moveOnCategoryRepository)
+    nonArrivalEntityFactory = PersistedFactory(NonArrivalEntityFactory(), nonArrivalRepository)
+    cancellationEntityFactory = PersistedFactory(CancellationEntityFactory(), cancellationRepository)
+    cancellationReasonEntityFactory = PersistedFactory(CancellationReasonEntityFactory(), cancellationReasonRepository)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/LostBedsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/LostBedsTest.kt
@@ -13,12 +13,12 @@ class LostBedsTest : IntegrationTestBase() {
 
   @Test
   fun `Create Lost Beds without JWT returns 401`() {
-    val premises = premisesEntityFactory.configure {
+    val premises = premisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion {
-        probationRegionEntityFactory.configure { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }.produceAndPersist()
+        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
       }
-    }.produceAndPersist()
+    }
 
     webTestClient.post()
       .uri("/premises/${premises.id}/lost-beds")
@@ -61,12 +61,12 @@ class LostBedsTest : IntegrationTestBase() {
 
   @Test
   fun `Create Lost Beds with endDate before startDate returns Bad Request with correct body`() {
-    val premises = premisesEntityFactory.configure {
+    val premises = premisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion {
-        probationRegionEntityFactory.configure { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }.produceAndPersist()
+        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
       }
-    }.produceAndPersist()
+    }
 
     val jwt = jwtAuthHelper.createValidJwt()
 
@@ -97,12 +97,12 @@ class LostBedsTest : IntegrationTestBase() {
 
   @Test
   fun `Create Lost Beds with less than 1 bed returns Bad Request with correct body`() {
-    val premises = premisesEntityFactory.configure {
+    val premises = premisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion {
-        probationRegionEntityFactory.configure { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }.produceAndPersist()
+        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
       }
-    }.produceAndPersist()
+    }
 
     val jwt = jwtAuthHelper.createValidJwt()
 
@@ -133,13 +133,13 @@ class LostBedsTest : IntegrationTestBase() {
 
   @Test
   fun `Create Lost Beds returns OK with correct body`() {
-    val premises = premisesEntityFactory.configure {
+    val premises = premisesEntityFactory.produceAndPersist {
       withTotalBeds(3)
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion {
-        probationRegionEntityFactory.configure { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }.produceAndPersist()
+        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
       }
-    }.produceAndPersist()
+    }
 
     val jwt = jwtAuthHelper.createValidJwt()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/LostBedsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/LostBedsTest.kt
@@ -13,10 +13,12 @@ class LostBedsTest : IntegrationTestBase() {
 
   @Test
   fun `Create Lost Beds without JWT returns 401`() {
-    val premises = premisesEntityFactory
-      .withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      .withYieldedProbationRegion { probationRegionEntityFactory.withYieldedApArea { apAreaEntityFactory.produceAndPersist() }.produceAndPersist() }
-      .produceAndPersist()
+    val premises = premisesEntityFactory.configure {
+      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.configure { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }.produceAndPersist()
+      }
+    }.produceAndPersist()
 
     webTestClient.post()
       .uri("/premises/${premises.id}/lost-beds")
@@ -59,10 +61,12 @@ class LostBedsTest : IntegrationTestBase() {
 
   @Test
   fun `Create Lost Beds with endDate before startDate returns Bad Request with correct body`() {
-    val premises = premisesEntityFactory
-      .withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      .withYieldedProbationRegion { probationRegionEntityFactory.withYieldedApArea { apAreaEntityFactory.produceAndPersist() }.produceAndPersist() }
-      .produceAndPersist()
+    val premises = premisesEntityFactory.configure {
+      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.configure { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }.produceAndPersist()
+      }
+    }.produceAndPersist()
 
     val jwt = jwtAuthHelper.createValidJwt()
 
@@ -93,10 +97,12 @@ class LostBedsTest : IntegrationTestBase() {
 
   @Test
   fun `Create Lost Beds with less than 1 bed returns Bad Request with correct body`() {
-    val premises = premisesEntityFactory
-      .withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      .withYieldedProbationRegion { probationRegionEntityFactory.withYieldedApArea { apAreaEntityFactory.produceAndPersist() }.produceAndPersist() }
-      .produceAndPersist()
+    val premises = premisesEntityFactory.configure {
+      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.configure { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }.produceAndPersist()
+      }
+    }.produceAndPersist()
 
     val jwt = jwtAuthHelper.createValidJwt()
 
@@ -127,11 +133,13 @@ class LostBedsTest : IntegrationTestBase() {
 
   @Test
   fun `Create Lost Beds returns OK with correct body`() {
-    val premises = premisesEntityFactory
-      .withTotalBeds(3)
-      .withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      .withYieldedProbationRegion { probationRegionEntityFactory.withYieldedApArea { apAreaEntityFactory.produceAndPersist() }.produceAndPersist() }
-      .produceAndPersist()
+    val premises = premisesEntityFactory.configure {
+      withTotalBeds(3)
+      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.configure { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }.produceAndPersist()
+      }
+    }.produceAndPersist()
 
     val jwt = jwtAuthHelper.createValidJwt()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
@@ -11,10 +11,12 @@ import java.util.UUID
 class PremisesTest : IntegrationTestBase() {
   @Test
   fun `Get all Premises returns OK with correct body`() {
-    val premises = premisesEntityFactory
-      .withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      .withYieldedProbationRegion { probationRegionEntityFactory.withYieldedApArea { apAreaEntityFactory.produceAndPersist() }.produceAndPersist() }
-      .produceAndPersistMultiple(10)
+    val premises = premisesEntityFactory.configure {
+      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.configure { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }.produceAndPersist()
+      }
+    }.produceAndPersistMultiple(10)
 
     val expectedJson = objectMapper.writeValueAsString(premises.map(::premisesEntityToExpectedApiResponse))
 
@@ -32,10 +34,12 @@ class PremisesTest : IntegrationTestBase() {
 
   @Test
   fun `Get Premises by ID returns OK with correct body`() {
-    val premises = premisesEntityFactory
-      .withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      .withYieldedProbationRegion { probationRegionEntityFactory.withYieldedApArea { apAreaEntityFactory.produceAndPersist() }.produceAndPersist() }
-      .produceAndPersistMultiple(5)
+    val premises = premisesEntityFactory.configure {
+      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.configure { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }.produceAndPersist()
+      }
+    }.produceAndPersistMultiple(5)
 
     val premisesToGet = premises[2]
     val expectedJson = objectMapper.writeValueAsString(premisesEntityToExpectedApiResponse(premises[2]))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
@@ -11,12 +11,12 @@ import java.util.UUID
 class PremisesTest : IntegrationTestBase() {
   @Test
   fun `Get all Premises returns OK with correct body`() {
-    val premises = premisesEntityFactory.configure {
+    val premises = premisesEntityFactory.produceAndPersistMultiple(10) {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion {
-        probationRegionEntityFactory.configure { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }.produceAndPersist()
+        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
       }
-    }.produceAndPersistMultiple(10)
+    }
 
     val expectedJson = objectMapper.writeValueAsString(premises.map(::premisesEntityToExpectedApiResponse))
 
@@ -34,12 +34,12 @@ class PremisesTest : IntegrationTestBase() {
 
   @Test
   fun `Get Premises by ID returns OK with correct body`() {
-    val premises = premisesEntityFactory.configure {
+    val premises = premisesEntityFactory.produceAndPersistMultiple(5) {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion {
-        probationRegionEntityFactory.configure { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }.produceAndPersist()
+        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
       }
-    }.produceAndPersistMultiple(5)
+    }
 
     val premisesToGet = premises[2]
     val expectedJson = objectMapper.writeValueAsString(premisesEntityToExpectedApiResponse(premises[2]))


### PR DESCRIPTION
Change our derived Factory classes to derive from KFactory's factory directly instead of PersistedFactory.  Change PersistedFactory to be a standalone class that composes a KFactory and a repository.  Configure the factory and produceAndPersist objects in one call which takes a configuration block as second argument.