### PR TITLE
549 - Add available beds for today field to Premises responses

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PremisesTransformer.kt
@@ -10,12 +10,13 @@ class PremisesTransformer(
   private val apAreaTransformer: ApAreaTransformer,
   private val localAuthorityAreaTransformer: LocalAuthorityAreaTransformer
 ) {
-  fun transformJpaToApi(jpa: PremisesEntity) = Premises(
+  fun transformJpaToApi(jpa: PremisesEntity, availableBedsForToday: Int) = Premises(
     id = jpa.id,
     name = jpa.name,
     apCode = jpa.apCode,
     postcode = jpa.postcode,
     bedCount = jpa.totalBeds,
+    availableBedsForToday = availableBedsForToday,
     probationRegion = probationRegionTransformer.transformJpaToApi(jpa.probationRegion),
     apArea = apAreaTransformer.transformJpaToApi(jpa.probationRegion.apArea),
     localAuthorityArea = localAuthorityAreaTransformer.transformJpaToApi(jpa.localAuthorityArea)

--- a/src/main/resources/static/mini-manage-api-stubs.yml
+++ b/src/main/resources/static/mini-manage-api-stubs.yml
@@ -627,6 +627,9 @@ components:
         bedCount:
           type: integer
           example: 22
+        availableBedsForToday:
+          type: integer
+          example: 20
         probationRegion:
           $ref: '#/components/schemas/ProbationRegion'
         apArea:
@@ -639,6 +642,7 @@ components:
         - apCode
         - postcode
         - bedCount
+        - availableBedsForToday
         - probationRegion
         - apArea
         - localAuthorityArea


### PR DESCRIPTION
Change get all premises and get premises by ID endpoints to include availableBedsForToday field in response