### PR TITLE
599 - Extend Bookings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -8,10 +8,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.Arrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.Booking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.Cancellation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.DateCapacity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.Extension
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.LostBed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.NewArrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.NewBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.NewCancellation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.NewExtension
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.NewLostBed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.Premises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ArrivalEntity
@@ -109,6 +111,7 @@ class PremisesController(
         departure = null,
         nonArrival = null,
         cancellation = null,
+        extensions = mutableListOf(),
         premises = premises
       )
     )
@@ -185,6 +188,14 @@ class PremisesController(
     )
 
     return ResponseEntity.ok(cancellationTransformer.transformJpaToApi(cancellation))
+  }
+
+  override fun premisesPremisesIdBookingsBookingIdExtensionsPost(
+    premisesId: UUID,
+    bookingId: UUID,
+    body: NewExtension
+  ): ResponseEntity<Extension> {
+    return super.premisesPremisesIdBookingsBookingIdExtensionsPost(premisesId, bookingId, body)
   }
 
   override fun premisesPremisesIdLostBedsPost(premisesId: UUID, body: NewLostBed): ResponseEntity<LostBed> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -10,6 +10,7 @@ import javax.persistence.Entity
 import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
+import javax.persistence.OneToMany
 import javax.persistence.OneToOne
 import javax.persistence.Table
 
@@ -41,6 +42,8 @@ data class BookingEntity(
   var nonArrival: NonArrivalEntity?,
   @OneToOne(mappedBy = "booking")
   var cancellation: CancellationEntity?,
+  @OneToMany(mappedBy = "booking")
+  var extensions: MutableList<ExtensionEntity>,
   @ManyToOne
   @JoinColumn(name = "premises_id")
   var premises: PremisesEntity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -30,7 +30,7 @@ data class BookingEntity(
   val id: UUID,
   var crn: String,
   val arrivalDate: LocalDate,
-  val departureDate: LocalDate,
+  var departureDate: LocalDate,
   @ManyToOne
   @JoinColumn(name = "key_worker_id")
   var keyWorker: KeyWorkerEntity,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ExtensionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ExtensionEntity.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+import java.util.Objects
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.Table
+
+@Repository
+interface ExtensionRepository : JpaRepository<ExtensionEntity, UUID>
+
+@Entity
+@Table(name = "extensions")
+data class ExtensionEntity(
+  @Id
+  val id: UUID,
+  val previousDepartureDate: LocalDate,
+  val newDepartureDate: LocalDate,
+  val notes: String?,
+  @ManyToOne
+  @JoinColumn(name = "booking_id")
+  var booking: BookingEntity
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is ExtensionEntity) return false
+
+    if (id != other.id) return false
+    if (previousDepartureDate != other.previousDepartureDate) return false
+    if (newDepartureDate != other.newDepartureDate) return false
+    if (notes != other.notes) return false
+
+    return true
+  }
+
+  override fun hashCode() = Objects.hash(id, previousDepartureDate, newDepartureDate, notes)
+
+  override fun toString() = "ExtensionEntity:$id"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -8,16 +8,31 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExtensionEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExtensionRepository
 import java.util.UUID
+import javax.transaction.Transactional
 
 @Service
 class BookingService(
   private val bookingRepository: BookingRepository,
   private val arrivalRepository: ArrivalRepository,
-  private val cancellationRepository: CancellationRepository
+  private val cancellationRepository: CancellationRepository,
+  private val extensionRepository: ExtensionRepository
 ) {
   fun createBooking(bookingEntity: BookingEntity): BookingEntity = bookingRepository.save(bookingEntity)
+  fun updateBooking(bookingEntity: BookingEntity): BookingEntity = bookingRepository.save(bookingEntity)
   fun getBooking(id: UUID) = bookingRepository.findByIdOrNull(id)
   fun createArrival(arrivalEntity: ArrivalEntity): ArrivalEntity = arrivalRepository.save(arrivalEntity)
   fun createCancellation(cancellationEntity: CancellationEntity): CancellationEntity = cancellationRepository.save(cancellationEntity)
+
+  @Transactional
+  fun createExtension(bookingEntity: BookingEntity, extensionEntity: ExtensionEntity): ExtensionEntity {
+    val extension = extensionRepository.save(extensionEntity)
+    bookingEntity.departureDate = extensionEntity.newDepartureDate
+    bookingEntity.extensions.add(extension)
+    updateBooking(bookingEntity)
+
+    return extensionEntity
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
@@ -13,7 +13,8 @@ class BookingTransformer(
   private val arrivalTransformer: ArrivalTransformer,
   private val departureTransformer: DepartureTransformer,
   private val nonArrivalTransformer: NonArrivalTransformer,
-  private val cancellationTransformer: CancellationTransformer
+  private val cancellationTransformer: CancellationTransformer,
+  private val extensionTransformer: ExtensionTransformer
 ) {
   fun transformJpaToApi(jpa: BookingEntity, person: Person) = Booking(
     id = jpa.id,
@@ -25,7 +26,8 @@ class BookingTransformer(
     arrival = arrivalTransformer.transformJpaToApi(jpa.arrival),
     departure = departureTransformer.transformJpaToApi(jpa.departure),
     nonArrival = nonArrivalTransformer.transformJpaToApi(jpa.nonArrival),
-    cancellation = cancellationTransformer.transformJpaToApi(jpa.cancellation)
+    cancellation = cancellationTransformer.transformJpaToApi(jpa.cancellation),
+    extensions = jpa.extensions.map(extensionTransformer::transformJpaToApi)
   )
 
   private fun determineStatus(jpa: BookingEntity) = when {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ExtensionTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ExtensionTransformer.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.Extension
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExtensionEntity
+
+@Component
+class ExtensionTransformer() {
+  fun transformJpaToApi(jpa: ExtensionEntity) = Extension(
+    id = jpa.id,
+    bookingId = jpa.booking.id,
+    previousDepartureDate = jpa.previousDepartureDate,
+    newDepartureDate = jpa.newDepartureDate,
+    notes = jpa.notes
+  )
+}

--- a/src/main/resources/db/migration/20220817152352__add_booking_extension_table.sql
+++ b/src/main/resources/db/migration/20220817152352__add_booking_extension_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE extensions (
+    id UUID NOT NULL,
+    booking_id UUID NOT NULL,
+    previous_departure_date DATE NOT NULL,
+    new_departure_date DATE NOT NULL,
+    notes TEXT,
+    PRIMARY KEY (id),
+    FOREIGN KEY (booking_id) REFERENCES bookings(id)
+);

--- a/src/main/resources/static/mini-manage-api-stubs.yml
+++ b/src/main/resources/static/mini-manage-api-stubs.yml
@@ -256,6 +256,59 @@ paths:
         500:
           $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
+  /premises/{premisesId}/bookings/{bookingId}/extensions:
+    post:
+      tags:
+        - Operations on bookings
+      summary: Posts an extension to a specified approved premises booking
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises the booking is related to
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: bookingId
+          in: path
+          description: ID of the booking
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: details of the extension
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/NewExtension'
+        required: true
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Extension'
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid premises ID or booking ID
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
+      x-codegen-request-body-name: body
   /premises/{premisesId}/bookings/{bookingId}/departures:
     post:
       tags:
@@ -830,6 +883,10 @@ components:
               - not-arrived
               - departed
               - cancelled
+            extensions:
+              type: array
+              items:
+                $ref: '#/components/schemas/Extension'
             arrival:
               nullable: true
               allOf:
@@ -848,6 +905,7 @@ components:
               - $ref: '#/components/schemas/Cancellation'
           required:
             - status
+            - extensions
     Person:
       type: object
       properties:
@@ -942,6 +1000,38 @@ components:
         - bookingId
         - date
         - reason
+    Extension:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        previousDepartureDate:
+          type: string
+          format: date
+        newDepartureDate:
+          type: string
+          format: date
+        notes:
+          type: string
+      required:
+        - id
+        - bookingId
+        - previousDepartureDate
+        - newDepartureDate
+    NewExtension:
+      type: object
+      properties:
+        newDepartureDate:
+          type: string
+          format: date
+        notes:
+          type: string
+      required:
+        - newDepartureDate
     Departure:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExtensionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.KeyWorkerEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
@@ -26,6 +27,7 @@ class BookingEntityFactory : Factory<BookingEntity> {
   private var departure: Yielded<DepartureEntity>? = null
   private var nonArrival: Yielded<NonArrivalEntity>? = null
   private var cancellation: Yielded<CancellationEntity>? = null
+  private var extensions: Yielded<MutableList<ExtensionEntity>>? = null
   private var premises: Yielded<PremisesEntity>? = null
 
   fun withId(id: UUID) = apply {
@@ -84,6 +86,14 @@ class BookingEntityFactory : Factory<BookingEntity> {
     this.cancellation = { cancellation }
   }
 
+  fun withYieldedExtensions(extensions: Yielded<MutableList<ExtensionEntity>>) = apply {
+    this.extensions = extensions
+  }
+
+  fun withExtensions(extensions: MutableList<ExtensionEntity>) = apply {
+    this.extensions = { extensions }
+  }
+
   fun withYieldedPremises(premises: Yielded<PremisesEntity>) = apply {
     this.premises = premises
   }
@@ -102,6 +112,7 @@ class BookingEntityFactory : Factory<BookingEntity> {
     departure = this.departure?.invoke(),
     nonArrival = this.nonArrival?.invoke(),
     cancellation = this.cancellation?.invoke(),
+    extensions = this.extensions?.invoke() ?: mutableListOf(),
     premises = this.premises?.invoke() ?: throw RuntimeException("Must provide a Premises")
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ExtensionEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ExtensionEntityFactory.kt
@@ -1,0 +1,50 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExtensionEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.LocalDate
+import java.util.UUID
+
+class ExtensionEntityFactory : Factory<ExtensionEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var previousDepartureDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore() }
+  private var newDepartureDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore() }
+  private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
+  private var booking: Yielded<BookingEntity>? = null
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withPreviousDepartureDate(previousDepartureDate: LocalDate) = apply {
+    this.previousDepartureDate = { previousDepartureDate }
+  }
+
+  fun withNewDepartureDate(newDepartureDate: LocalDate) = apply {
+    this.newDepartureDate = { newDepartureDate }
+  }
+
+  fun withNotes(notes: String) = apply {
+    this.notes = { notes }
+  }
+
+  fun withYieldedBooking(booking: Yielded<BookingEntity>) = apply {
+    this.booking = booking
+  }
+
+  fun withBooking(booking: BookingEntity) = apply {
+    this.booking = { booking }
+  }
+
+  override fun produce(): ExtensionEntity = ExtensionEntity(
+    id = this.id(),
+    previousDepartureDate = this.previousDepartureDate(),
+    newDepartureDate = this.newDepartureDate(),
+    notes = this.notes(),
+    booking = this.booking?.invoke() ?: throw RuntimeException("Booking must be provided")
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -72,6 +72,7 @@ class BookingTest : IntegrationTestBase() {
     bookings[1].let { it.arrival = arrivalEntityFactory.produceAndPersist { withBooking(it) } }
     bookings[2].let {
       it.arrival = arrivalEntityFactory.produceAndPersist { withBooking(it) }
+      it.extensions = extensionEntityFactory.produceAndPersistMultiple(1) { withBooking(it) }.toMutableList()
       it.departure = departureEntityFactory.produceAndPersist {
         withBooking(it)
         withYieldedDestinationProvider { destinationProviderEntityFactory.produceAndPersist() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -1,11 +1,14 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.test.web.reactive.server.expectBodyList
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.NewArrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.NewBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.NewCancellation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.health.api.model.NewExtension
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Person
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingTransformer
 import java.time.LocalDate
@@ -529,5 +532,114 @@ class BookingTest : IntegrationTestBase() {
       .jsonPath(".reason.id").isEqualTo(cancellationReason.id.toString())
       .jsonPath(".reason.name").isEqualTo(cancellationReason.name)
       .jsonPath(".reason.isActive").isEqualTo(true)
+  }
+
+  @Test
+  fun `Create Extension without JWT returns 401`() {
+    webTestClient.post()
+      .uri("/premises/e0f03aa2-1468-441c-aa98-0b98d86b67f9/bookings/1617e729-13f3-4158-bd88-c59affdb8a45/extensions")
+      .bodyValue(
+        NewExtension(
+          newDepartureDate = LocalDate.parse("2022-08-20"),
+          notes = null
+        )
+      )
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `Create Extension on non existent Premises returns 404`() {
+    val jwt = jwtAuthHelper.createValidJwt()
+
+    webTestClient.post()
+      .uri("/premises/9054b6a8-65ad-4d55-91ee-26ba65e05488/bookings/e00efccb-5551-42fb-afff-2de7cb8277ff/extensions")
+      .header("Authorization", "Bearer $jwt")
+      .bodyValue(
+        NewExtension(
+          newDepartureDate = LocalDate.parse("2022-08-20"),
+          notes = null
+        )
+      )
+      .exchange()
+      .expectStatus()
+      .isNotFound
+  }
+
+  @Test
+  fun `Create Extension on Booking with newDepartureDate behind current departureDate of Booking returns 400`() {
+    val booking = bookingEntityFactory.produceAndPersist {
+      withDepartureDate(LocalDate.parse("2022-08-20"))
+      withYieldedKeyWorker { keyWorkerEntityFactory.produceAndPersist() }
+      withYieldedPremises {
+        premisesEntityFactory.produceAndPersist {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+          }
+        }
+      }
+    }
+
+    val jwt = jwtAuthHelper.createValidJwt()
+
+    webTestClient.post()
+      .uri("/premises/${booking.premises.id}/bookings/${booking.id}/extensions")
+      .header("Authorization", "Bearer $jwt")
+      .bodyValue(
+        NewExtension(
+          newDepartureDate = LocalDate.parse("2022-08-19"),
+          notes = null
+        )
+      )
+      .exchange()
+      .expectStatus()
+      .isBadRequest
+      .expectBody()
+      .jsonPath(".invalid-params[0]").isEqualTo(
+        mapOf(
+          "propertyName" to "newDepartureDate",
+          "errorType" to "Must be after the Booking's current departure date (${booking.departureDate})"
+        )
+      )
+  }
+
+  @Test
+  fun `Create Extension on Booking returns OK with expected body, updates departureDate on Booking entity`() {
+    val booking = bookingEntityFactory.produceAndPersist {
+      withDepartureDate(LocalDate.parse("2022-08-20"))
+      withYieldedKeyWorker { keyWorkerEntityFactory.produceAndPersist() }
+      withYieldedPremises {
+        premisesEntityFactory.produceAndPersist {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+          }
+        }
+      }
+    }
+
+    val jwt = jwtAuthHelper.createValidJwt()
+
+    webTestClient.post()
+      .uri("/premises/${booking.premises.id}/bookings/${booking.id}/extensions")
+      .header("Authorization", "Bearer $jwt")
+      .bodyValue(
+        NewExtension(
+          newDepartureDate = LocalDate.parse("2022-08-22"),
+          notes = "notes"
+        )
+      )
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .jsonPath(".bookingId").isEqualTo(booking.id.toString())
+      .jsonPath(".previousDepartureDate").isEqualTo("2022-08-20")
+      .jsonPath(".newDepartureDate").isEqualTo("2022-08-22")
+      .jsonPath(".notes").isEqualTo("notes")
+
+    assertThat(bookingRepository.findByIdOrNull(booking.id)!!.departureDate).isEqualTo(LocalDate.parse("2022-08-22"))
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationReas
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DestinationProviderEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ExtensionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.KeyWorkerEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LostBedsEntityFactory
@@ -32,6 +33,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationR
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DestinationProviderEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExtensionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.KeyWorkerEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsEntity
@@ -47,6 +49,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.CancellationT
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DepartureReasonTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DepartureTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DestinationProviderTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ExtensionTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.KeyWorkerTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.LocalAuthorityAreaTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.LostBedsTestRepository
@@ -119,6 +122,9 @@ abstract class IntegrationTestBase {
   @Autowired
   lateinit var lostBedsRepository: LostBedsTestRepository
 
+  @Autowired
+  lateinit var extensionRepository: ExtensionTestRepository
+
   lateinit var probationRegionEntityFactory: PersistedFactory<ProbationRegionEntity, UUID, ProbationRegionEntityFactory>
   lateinit var apAreaEntityFactory: PersistedFactory<ApAreaEntity, UUID, ApAreaEntityFactory>
   lateinit var localAuthorityEntityFactory: PersistedFactory<LocalAuthorityAreaEntity, UUID, LocalAuthorityEntityFactory>
@@ -134,6 +140,7 @@ abstract class IntegrationTestBase {
   lateinit var cancellationEntityFactory: PersistedFactory<CancellationEntity, UUID, CancellationEntityFactory>
   lateinit var cancellationReasonEntityFactory: PersistedFactory<CancellationReasonEntity, UUID, CancellationReasonEntityFactory>
   lateinit var lostBedsEntityFactory: PersistedFactory<LostBedsEntity, UUID, LostBedsEntityFactory>
+  lateinit var extensionEntityFactory: PersistedFactory<ExtensionEntity, UUID, ExtensionEntityFactory>
 
   @BeforeEach
   fun beforeEach() {
@@ -158,5 +165,6 @@ abstract class IntegrationTestBase {
     cancellationEntityFactory = PersistedFactory(CancellationEntityFactory(), cancellationRepository)
     cancellationReasonEntityFactory = PersistedFactory(CancellationReasonEntityFactory(), cancellationReasonRepository)
     lostBedsEntityFactory = PersistedFactory(LostBedsEntityFactory(), lostBedsRepository)
+    extensionEntityFactory = PersistedFactory(ExtensionEntityFactory(), extensionRepository)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/ExtensionTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/ExtensionTestRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExtensionEntity
+import java.util.UUID
+
+@Repository
+interface ExtensionTestRepository : JpaRepository<ExtensionEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -33,6 +33,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ArrivalTrans
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CancellationTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DepartureTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ExtensionTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.KeyWorkerTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NonArrivalTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
@@ -47,6 +48,7 @@ class BookingTransformerTest {
   private val mockNonArrivalTransformer = mockk<NonArrivalTransformer>()
   private val mockCancellationTransformer = mockk<CancellationTransformer>()
   private val mockDepartureTransformer = mockk<DepartureTransformer>()
+  private val mockExtensionTransformer = mockk<ExtensionTransformer>()
 
   private val bookingTransformer = BookingTransformer(
     mockPersonTransformer,
@@ -54,7 +56,8 @@ class BookingTransformerTest {
     mockArrivalTransformer,
     mockDepartureTransformer,
     mockNonArrivalTransformer,
-    mockCancellationTransformer
+    mockCancellationTransformer,
+    mockExtensionTransformer
   )
 
   private val premisesEntity = PremisesEntity(
@@ -99,6 +102,7 @@ class BookingTransformerTest {
     departure = null,
     nonArrival = null,
     cancellation = null,
+    extensions = mutableListOf(),
     premises = premisesEntity
   )
 
@@ -140,7 +144,8 @@ class BookingTransformerTest {
           name = "name",
           isActive = true
         ),
-        status = Booking.Status.awaitingMinusArrival
+        status = Booking.Status.awaitingMinusArrival,
+        extensions = listOf()
       )
     )
   }
@@ -183,7 +188,8 @@ class BookingTransformerTest {
           date = LocalDate.parse("2022-08-10"),
           reason = "Unknown",
           notes = null
-        )
+        ),
+        extensions = listOf()
       )
     )
   }
@@ -226,7 +232,8 @@ class BookingTransformerTest {
           arrivalDate = LocalDate.parse("2022-08-10"),
           expectedDepartureDate = LocalDate.parse("2022-08-16"),
           notes = null
-        )
+        ),
+        extensions = listOf()
       )
     )
   }
@@ -269,7 +276,8 @@ class BookingTransformerTest {
           date = LocalDate.parse("2022-08-10"),
           reason = CancellationReason(id = UUID.fromString("aa4ee8cf-3580-44e1-a3e1-6f3ee7d5ec67"), name = "Because", isActive = true),
           notes = null
-        )
+        ),
+        extensions = listOf()
       )
     )
   }
@@ -375,7 +383,8 @@ class BookingTransformerTest {
             isActive = true
           ),
           notes = null
-        )
+        ),
+        extensions = listOf()
       )
     )
   }


### PR DESCRIPTION
Add Extension tables to DB - extend the GET /premises/{id}/bookings endpoint to return the current extensions in the body.

Add POST /premises/{id}/bookings/{booking id}/extensions endpoint to create an extension:
 - Extension must be to a date later than the current departure date