### PR TITLE
Enable out of order flyway migrations.

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,7 @@ spring:
 
   flyway:
     sql-migration-prefix: ""
+    outOfOrder: true
 
   jpa:
     hibernate:


### PR DESCRIPTION
When a longer-lived-branch is merged after a shorter-lived-branch where both contain a migration a timestamp can be skipped over (i.e. an earlier timestamped migration is deployed later) - this should allow them to still be run.