### PR TITLE
684 - Expose risk information

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3"
 services:
   database:
     image: "postgres"
+    container_name: approved-premises-postgres-dev
     environment:
       - POSTGRES_USER=localdev
       - POSTGRES_PASSWORD=localdev_password
@@ -13,6 +14,7 @@ services:
 
   hmpps-auth:
     image: quay.io/hmpps/hmpps-auth:latest
+    container_name: hmpps-auth
     ports:
       - "9091:8080"
     healthcheck:
@@ -28,13 +30,34 @@ services:
     container_name: community-api
     ports:
       - "9590:8080"
-      - "9592:9592"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
     environment:
       - SERVER_PORT=8080
       - SPRING_PROFILES_ACTIVE=dev
       - SPRING_H2_CONSOLE_SETTINGS_WEBALLOWOTHERS=true
+
+  hmpps-assess-risks-and-needs:
+    image: quay.io/hmpps/hmpps-assess-risks-and-needs
+    container_name: assess-risks-and-needs
+    ports:
+      - "9580:8080"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+    environment:
+      - SERVER_PORT=8080
+      - SPRING_PROFILES_ACTIVE=oasys-rsr,dev
+      - OAUTH_ENDPOINT_URL=http://hmpps-auth:8080/auth
+      - ASSESSMENT-API_BASE-URL=http://wiremock:8080
+      - COMMUNITY-API_BASE-URL=http://community-api:8080
+
+  wiremock:
+    image: rodolpheche/wiremock
+    container_name: wiremock
+    ports:
+      - "9004:8080"
+    volumes:
+      - ./wiremock:/home/wiremock
 
 volumes:
   database-data-development:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/AssessRisksAndNeedsApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/AssessRisksAndNeedsApiClient.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.client
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.assessrisksandneeds.RoshRisks
+
+@Component
+class AssessRisksAndNeedsApiClient(
+  @Qualifier("assessRisksAndNeedsApiWebClient") webClient: WebClient,
+  objectMapper: ObjectMapper
+) : BaseHMPPSClient(webClient, objectMapper) {
+  fun getRoshRisks(crn: String, jwt: String) = getRequest<RoshRisks> {
+    withHeader("Authorization", "Bearer $jwt")
+    path = "/risks/crn/$crn"
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CommunityApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CommunityApiClient.kt
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Registrations
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.UserOffenderAccess
 
 @Component
@@ -18,5 +19,9 @@ class CommunityApiClient(
 
   fun getUserAccessForOffenderCrn(userDistinguishedName: String, crn: String) = getRequest<UserOffenderAccess> {
     path = "/secure/offenders/crn/$crn/user/$userDistinguishedName/userAccess"
+  }
+
+  fun getRegistrationsForOffenderCrn(crn: String) = getRequest<Registrations> {
+    path = "/secure/offenders/crn/$crn/registrations?activeOnly=true"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/HMPPSTierApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/HMPPSTierApiClient.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.client
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.hmppstier.Tier
+
+@Component
+class HMPPSTierApiClient(
+  @Qualifier("hmppsTierApiWebClient") webClient: WebClient,
+  objectMapper: ObjectMapper
+) : BaseHMPPSClient(webClient, objectMapper) {
+  fun getTier(crn: String) = getRequest<Tier> {
+    path = "/crn/$crn/tier"
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
@@ -34,4 +34,20 @@ class WebClientConfiguration {
       .baseUrl(assessRisksAndNeedsApiBaseUrl)
       .build()
   }
+
+  @Bean(name = ["hmppsTierApiWebClient"])
+  fun hmppsTierApiWebClient(
+    clientRegistrations: ClientRegistrationRepository,
+    authorizedClients: OAuth2AuthorizedClientRepository,
+    @Value("\${services.hmpps-tier.base-url}") hmppsTierApiBaseUrl: String
+  ): WebClient {
+    val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(clientRegistrations, authorizedClients)
+
+    oauth2Client.setDefaultClientRegistrationId("hmpps-tier")
+
+    return WebClient.builder()
+      .baseUrl(hmppsTierApiBaseUrl)
+      .filter(oauth2Client)
+      .build()
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
@@ -25,4 +25,13 @@ class WebClientConfiguration {
       .filter(oauth2Client)
       .build()
   }
+
+  @Bean(name = ["assessRisksAndNeedsApiWebClient"])
+  fun assessRisksAndNeedsApiWebClient(
+    @Value("\${services.assess-risks-and-needs-api.base-url}") assessRisksAndNeedsApiBaseUrl: String
+  ): WebClient {
+    return WebClient.builder()
+      .baseUrl(assessRisksAndNeedsApiBaseUrl)
+      .build()
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PersonController.kt
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.PersonApiDelegate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.AuthAwareAuthenticationToken
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
@@ -17,15 +18,24 @@ class PersonController(
   private val personTransformer: PersonTransformer
 ) : PersonApiDelegate {
   override fun personSearchGet(crn: String): ResponseEntity<Person> {
+    val principal = getDeliusPrincipalOrThrow()
+
+    return when (val offenderResult = offenderService.getOffenderByCrn(crn, principal.name)) {
+      is AuthorisableActionResult.NotFound -> throw NotFoundProblem(crn, "Person")
+      is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
+      is AuthorisableActionResult.Success -> ResponseEntity.ok(
+        personTransformer.transformModelToApi(offenderResult.entity)
+      )
+    }
+  }
+
+  private fun getDeliusPrincipalOrThrow(): AuthAwareAuthenticationToken {
     val principal = SecurityContextHolder.getContext().authentication as AuthAwareAuthenticationToken
 
     if (principal.token.claims["auth_source"] != "delius") {
       throw ForbiddenProblem()
     }
 
-    val offender = offenderService.getOffenderByCrn(crn, principal.name)
-      ?: throw NotFoundProblem(crn, "Person")
-
-    return ResponseEntity.ok(personTransformer.transformModelToApi(offender))
+    return principal
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PersonController.kt
@@ -5,17 +5,20 @@ import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.PersonApiDelegate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.AuthAwareAuthenticationToken
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RisksTransformer
 
 @Service
 class PersonController(
   private val offenderService: OffenderService,
-  private val personTransformer: PersonTransformer
+  private val personTransformer: PersonTransformer,
+  private val risksTransformer: RisksTransformer
 ) : PersonApiDelegate {
   override fun personSearchGet(crn: String): ResponseEntity<Person> {
     val principal = getDeliusPrincipalOrThrow()
@@ -27,6 +30,18 @@ class PersonController(
         personTransformer.transformModelToApi(offenderResult.entity)
       )
     }
+  }
+
+  override fun personCrnRisksGet(crn: String): ResponseEntity<PersonRisks> {
+    val principal = getDeliusPrincipalOrThrow()
+
+    val risks = when (val risksResult = offenderService.getRiskByCrn(crn, principal.token.tokenValue, principal.name)) {
+      is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
+      is AuthorisableActionResult.NotFound -> throw NotFoundProblem(crn, "Person")
+      is AuthorisableActionResult.Success -> risksResult.entity
+    }
+
+    return ResponseEntity.ok(risksTransformer.transformDomainToApi(risks))
   }
 
   private fun getDeliusPrincipalOrThrow(): AuthAwareAuthenticationToken {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/AuthorisableActionResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/AuthorisableActionResult.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.model
+
+sealed interface AuthorisableActionResult<EntityType> {
+  data class Success<EntityType>(val entity: EntityType) : AuthorisableActionResult<EntityType>
+  class Unauthorised<EntityType> : AuthorisableActionResult<EntityType>
+  class NotFound<EntityType> : AuthorisableActionResult<EntityType>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/PersonRisks.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/PersonRisks.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.model
+
+import java.time.LocalDate
+
+data class RiskWithStatus<T>(val status: RiskStatus, val value: T? = null) {
+  constructor(value: T?) : this(RiskStatus.Retrieved, value)
+}
+
+enum class RiskStatus {
+  Retrieved,
+  NotFound,
+  Error
+}
+
+data class PersonRisks(
+  val crn: String,
+  val roshRisks: RiskWithStatus<RoshRisks>,
+  val mappa: RiskWithStatus<Mappa>,
+  val tier: RiskWithStatus<RiskTier>,
+  val flags: RiskWithStatus<List<String>>
+)
+
+data class RoshRisks(
+  val overallRisk: String,
+  val riskToChildren: String,
+  val riskToPublic: String,
+  val riskToKnownAdult: String,
+  val riskToStaff: String,
+  val lastUpdated: LocalDate?
+)
+
+data class Mappa(
+  val level: String,
+  val lastUpdated: LocalDate
+)
+
+data class RiskTier(
+  val level: String,
+  val lastUpdated: LocalDate
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/assessrisksandneeds/RoshRisks.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/assessrisksandneeds/RoshRisks.kt
@@ -1,0 +1,59 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.assessrisksandneeds
+
+import java.time.LocalDateTime
+
+data class RoshRisks(
+  val riskToSelf: RoshRiskToSelf,
+  val otherRisks: OtherRoshRisks,
+  val summary: RoshRisksSummary,
+  val assessedOn: LocalDateTime?
+)
+
+data class RoshRiskToSelf(
+  val suicide: Risk?,
+  val custody: Risk?,
+  val hostelSetting: Risk?,
+  val vulnerability: Risk?,
+  val assessedOn: LocalDateTime?
+)
+
+data class OtherRoshRisks(
+  val escapeOrAbscond: Response?,
+  val controlIssuesDisruptiveBehaviour: Response?,
+  val breachOfTrust: Response?,
+  val riskToOtherPrisoners: Response?,
+  val assessedOn: LocalDateTime?
+)
+
+data class RoshRisksSummary(
+  val whoIsAtRisk: String?,
+  val natureOfRisk: String?,
+  val riskImminence: String?,
+  val riskIncreaseFactors: String?,
+  val riskMitigationFactors: String?,
+  val riskInCommunity: Map<RiskLevel?, List<String>>,
+  val riskInCustody: Map<RiskLevel?, List<String>>,
+  val assessedOn: LocalDateTime?,
+  val overallRiskLevel: RiskLevel? = null
+)
+
+data class Risk(
+  val risk: Response?,
+  val previous: Response?,
+  val previousConcernsText: String?,
+  val current: Response?,
+  val currentConcernsText: String?
+)
+
+enum class Response(val value: String) {
+  YES("Yes"),
+  NO("No"),
+  DK("Don't know")
+}
+
+enum class RiskLevel(val value: String) {
+  VERY_HIGH("Very High"),
+  HIGH("High"),
+  MEDIUM("Medium"),
+  LOW("Low")
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/Registrations.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/Registrations.kt
@@ -1,0 +1,52 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community
+
+import java.time.LocalDate
+
+data class Registrations(
+  val registrations: List<Registration>
+)
+
+data class Registration(
+  val registrationId: Long,
+  val offenderId: Long,
+  val register: RegistrationKeyValue,
+  val type: RegistrationKeyValue,
+  val riskColour: String,
+  val startDate: LocalDate,
+  val nextReviewDate: LocalDate,
+  val reviewPeriodMonths: Int,
+  val notes: String?,
+  val registeringTeam: RegistrationKeyValue,
+  val registeringOfficer: RegistrationStaffHuman,
+  val registeringProbationArea: RegistrationKeyValue,
+  val registerLevel: RegistrationKeyValue?,
+  val registerCategory: RegistrationKeyValue?,
+  val warnUser: Boolean,
+  val active: Boolean,
+  val endDate: LocalDate?,
+  val deregisteringOfficer: RegistrationStaffHuman?,
+  val deregisteringProbationArea: RegistrationKeyValue?,
+  val deregisteringNotes: String?,
+  val numberOfPreviousDeregistrations: Int,
+  val registrationReviews: List<RegistrationReview>?
+)
+
+data class RegistrationKeyValue(
+  val code: String,
+  val description: String
+)
+
+data class RegistrationStaffHuman(
+  val code: String,
+  val forenames: String,
+  val surname: String
+)
+
+data class RegistrationReview(
+  val reviewDate: LocalDate,
+  val reviewDateDue: LocalDate,
+  val notes: String?,
+  val reviewingTeam: RegistrationKeyValue,
+  val reviewingOfficer: RegistrationStaffHuman,
+  val completed: Boolean
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/hmppstier/Tier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/hmppstier/Tier.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.hmppstier
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class Tier(
+  val tierScore: String,
+  val calculationId: UUID,
+  val calculationDate: LocalDateTime
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
@@ -5,31 +5,32 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.shouldNotBeReached
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 
 @Service
 class OffenderService(private val communityApiClient: CommunityApiClient) {
-  fun getOffenderByCrn(crn: String, userDistinguishedName: String): OffenderDetailSummary? {
+  fun getOffenderByCrn(crn: String, userDistinguishedName: String): AuthorisableActionResult<OffenderDetailSummary> {
     val offender = when (val offenderResponse = communityApiClient.getOffenderDetailSummary(crn)) {
       is ClientResult.Success -> offenderResponse.body
-      is ClientResult.StatusCodeFailure -> if (offenderResponse.status == HttpStatus.NOT_FOUND) return null else offenderResponse.throwException()
+      is ClientResult.StatusCodeFailure -> if (offenderResponse.status == HttpStatus.NOT_FOUND) return AuthorisableActionResult.NotFound() else offenderResponse.throwException()
       is ClientResult.Failure -> offenderResponse.throwException()
       else -> shouldNotBeReached()
     }
 
     if (offender.currentExclusion || offender.currentRestriction) {
-      val access = when (val accessResponse = communityApiClient.getUserAccessForOffenderCrn(userDistinguishedName, crn)) {
-        is ClientResult.Success -> accessResponse.body
-        is ClientResult.Failure -> accessResponse.throwException()
-        else -> shouldNotBeReached()
-      }
+      val access =
+        when (val accessResponse = communityApiClient.getUserAccessForOffenderCrn(userDistinguishedName, crn)) {
+          is ClientResult.Success -> accessResponse.body
+          is ClientResult.Failure -> accessResponse.throwException()
+          else -> shouldNotBeReached()
+        }
 
       if (access.userExcluded || access.userRestricted) {
-        throw ForbiddenProblem()
+        return AuthorisableActionResult.Unauthorised()
       }
     }
 
-    return offender
+    return AuthorisableActionResult.Success(offender)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
@@ -2,14 +2,30 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.AssessRisksAndNeedsApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.HMPPSTierApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.shouldNotBeReached
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Mappa
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskTier
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RoshRisks
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.assessrisksandneeds.RiskLevel
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Registrations
 
 @Service
-class OffenderService(private val communityApiClient: CommunityApiClient) {
+class OffenderService(
+  private val communityApiClient: CommunityApiClient,
+  private val assessRisksAndNeedsApiClient: AssessRisksAndNeedsApiClient,
+  private val hmppsTierApiClient: HMPPSTierApiClient
+) {
+  private val ignoredRegisterTypesForFlags = listOf("RVHR", "RHRH", "RMRH", "RLRH", "MAPP")
+
   fun getOffenderByCrn(crn: String, userDistinguishedName: String): AuthorisableActionResult<OffenderDetailSummary> {
     val offender = when (val offenderResponse = communityApiClient.getOffenderDetailSummary(crn)) {
       is ClientResult.Success -> offenderResponse.body
@@ -32,5 +48,142 @@ class OffenderService(private val communityApiClient: CommunityApiClient) {
     }
 
     return AuthorisableActionResult.Success(offender)
+  }
+
+  fun getRiskByCrn(crn: String, jwt: String, userDistinguishedName: String): AuthorisableActionResult<PersonRisks> {
+    return when (getOffenderByCrn(crn, userDistinguishedName)) {
+      is AuthorisableActionResult.NotFound -> AuthorisableActionResult.NotFound()
+      is AuthorisableActionResult.Unauthorised -> AuthorisableActionResult.Unauthorised()
+      is AuthorisableActionResult.Success -> {
+        val registrationsResponse = communityApiClient.getRegistrationsForOffenderCrn(crn)
+
+        val risks = PersonRisks(
+          crn = crn,
+          roshRisks = getRoshRisksEnvelope(crn, jwt),
+          mappa = getMappaEnvelope(registrationsResponse),
+          tier = getRiskTierEnvelope(crn),
+          flags = getFlagsEnvelope(registrationsResponse)
+        )
+
+        AuthorisableActionResult.Success(
+          risks
+        )
+      }
+    }
+  }
+
+  private fun getRoshRisksEnvelope(crn: String, jwt: String): RiskWithStatus<RoshRisks> {
+    when (val roshRisksResponse = assessRisksAndNeedsApiClient.getRoshRisks(crn, jwt)) {
+      is ClientResult.Success -> {
+        val summary = roshRisksResponse.body.summary
+        return RiskWithStatus(
+          status = RiskStatus.Retrieved,
+          value = RoshRisks(
+            overallRisk = getOrThrow("overallRiskLevel") { summary.overallRiskLevel?.value },
+            riskToChildren = getRiskOrThrow("Children", summary.riskInCommunity),
+            riskToPublic = getRiskOrThrow("Public", summary.riskInCommunity),
+            riskToKnownAdult = getRiskOrThrow("Known Adult", summary.riskInCommunity),
+            riskToStaff = getRiskOrThrow("Staff", summary.riskInCommunity),
+            lastUpdated = summary.assessedOn?.toLocalDate()
+          )
+        )
+      }
+      is ClientResult.StatusCodeFailure -> return if (roshRisksResponse.status == HttpStatus.NOT_FOUND) {
+        RiskWithStatus(
+          status = RiskStatus.NotFound,
+          value = null
+        )
+      } else {
+        RiskWithStatus(
+          status = RiskStatus.Error,
+          value = null
+        )
+      }
+      is ClientResult.Failure -> return RiskWithStatus(
+        status = RiskStatus.Error,
+        value = null
+      )
+      else -> shouldNotBeReached()
+    }
+  }
+
+  private fun getMappaEnvelope(registrationsResponse: ClientResult<Registrations>): RiskWithStatus<Mappa> {
+    when (registrationsResponse) {
+      is ClientResult.Success -> {
+        return RiskWithStatus(
+          value = registrationsResponse.body.registrations.firstOrNull { it.type.code == "MAPP" }?.let { registration ->
+            Mappa(
+              level = "CAT ${registration.registerCategory!!.code}/LEVEL ${registration.registerLevel!!.code}",
+              lastUpdated = registration.registrationReviews?.filter { it.completed }?.maxOfOrNull { it.reviewDate } ?: registration.startDate
+            )
+          }
+        )
+      }
+      is ClientResult.StatusCodeFailure -> return if (registrationsResponse.status == HttpStatus.NOT_FOUND) {
+        RiskWithStatus(status = RiskStatus.NotFound)
+      } else {
+        RiskWithStatus(status = RiskStatus.Error)
+      }
+      is ClientResult.Failure -> {
+        return RiskWithStatus(status = RiskStatus.Error)
+      }
+      else -> shouldNotBeReached()
+    }
+  }
+
+  private fun getFlagsEnvelope(registrationsResponse: ClientResult<Registrations>): RiskWithStatus<List<String>> {
+    when (registrationsResponse) {
+      is ClientResult.Success -> {
+        return RiskWithStatus(
+          value = registrationsResponse.body.registrations.filter { !ignoredRegisterTypesForFlags.contains(it.type.code) }.map { it.type.description }
+        )
+      }
+      is ClientResult.StatusCodeFailure -> return if (registrationsResponse.status == HttpStatus.NOT_FOUND) {
+        RiskWithStatus(status = RiskStatus.NotFound)
+      } else {
+        RiskWithStatus(status = RiskStatus.Error)
+      }
+      is ClientResult.Failure -> {
+        return RiskWithStatus(status = RiskStatus.Error)
+      }
+      else -> shouldNotBeReached()
+    }
+  }
+
+  private fun getRiskTierEnvelope(crn: String): RiskWithStatus<RiskTier> {
+    when (val tierResponse = hmppsTierApiClient.getTier(crn)) {
+      is ClientResult.Success -> {
+        return RiskWithStatus(
+          status = RiskStatus.Retrieved,
+          value = RiskTier(
+            level = tierResponse.body.tierScore,
+            lastUpdated = tierResponse.body.calculationDate.toLocalDate()
+          )
+        )
+      }
+      is ClientResult.StatusCodeFailure -> return if (tierResponse.status == HttpStatus.NOT_FOUND) {
+        RiskWithStatus(status = RiskStatus.NotFound)
+      } else {
+        RiskWithStatus(status = RiskStatus.Error)
+      }
+      is ClientResult.Failure -> {
+        return RiskWithStatus(status = RiskStatus.Error)
+      }
+      else -> shouldNotBeReached()
+    }
+  }
+
+  private fun <T> getOrThrow(thing: String, getter: () -> T?): T {
+    return getter() ?: throw RuntimeException("Value unexpectedly missing when getting $thing")
+  }
+
+  private fun getRiskOrThrow(category: String, risks: Map<RiskLevel?, List<String>>): String {
+    risks.forEach {
+      if (it.value.contains(category)) {
+        return it.key?.value ?: throw RuntimeException("Risk level unexpectedly null when getting $category")
+      }
+    }
+
+    throw RuntimeException("Category not present in any Risk level when getting $category")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/RisksTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/RisksTransformer.kt
@@ -1,0 +1,58 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FlagsEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MappaEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RiskEnvelopeStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RiskTierEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RoshRisksEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskStatus
+
+@Component
+class RisksTransformer {
+  fun transformDomainToApi(domain: PersonRisks) = uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonRisks(
+    crn = domain.crn,
+    roshRisks = RoshRisksEnvelope(
+      status = transformDomainToApi(domain.roshRisks.status),
+      value = domain.roshRisks.value?.let {
+        uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RoshRisks(
+          overallRisk = it.overallRisk,
+          riskToChildren = it.riskToChildren,
+          riskToPublic = it.riskToPublic,
+          riskToKnownAdult = it.riskToKnownAdult,
+          riskToStaff = it.riskToStaff,
+          lastUpdated = it.lastUpdated
+        )
+      }
+    ),
+    mappa = MappaEnvelope(
+      status = transformDomainToApi(domain.mappa.status),
+      value = domain.mappa.value?.let {
+        uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Mappa(
+          level = it.level,
+          lastUpdated = it.lastUpdated
+        )
+      }
+    ),
+    tier = RiskTierEnvelope(
+      status = transformDomainToApi(domain.tier.status),
+      value = domain.tier.value?.let {
+        uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RiskTier(
+          level = it.level,
+          lastUpdated = it.lastUpdated
+        )
+      }
+    ),
+    flags = FlagsEnvelope(
+      status = transformDomainToApi(domain.flags.status),
+      value = domain.flags.value
+    )
+  )
+
+  private fun transformDomainToApi(domain: RiskStatus) = when (domain) {
+    RiskStatus.Retrieved -> RiskEnvelopeStatus.retrieved
+    RiskStatus.NotFound -> RiskEnvelopeStatus.notFound
+    RiskStatus.Error -> RiskEnvelopeStatus.error
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,6 +39,11 @@ spring:
             client-id: approved-premises-api
             client-secret: clientsecret
             authorization-grant-type: client_credentials
+          hmpps-tier:
+            provider: hmpps-auth
+            client-id: approved-premises-api
+            client-secret: clientsecret
+            authorization-grant-type: client_credentials
         provider:
           hmpps-auth:
             token-uri: ${hmpps.auth.url}/oauth/token
@@ -84,6 +89,8 @@ services:
     base-url: http://localhost:9590
   assess-risks-and-needs-api:
     base-url: http://localhost:9580
+  hmpps-tier:
+    base-url: http://localhost:9004
 
 hmpps:
   auth:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -82,6 +82,8 @@ management:
 services:
   community-api:
     base-url: http://localhost:9590
+  assess-risks-and-needs-api:
+    base-url: http://localhost:9580
 
 hmpps:
   auth:

--- a/src/main/resources/static/mini-manage-api-stubs.yml
+++ b/src/main/resources/static/mini-manage-api-stubs.yml
@@ -542,6 +542,41 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /person/{crn}/risks:
+    get:
+      summary: Returns the risks for a Person
+      parameters:
+        - name: crn
+          in: path
+          description: CRN of the Person to fetch risks for
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/PersonRisks'
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid CRN
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
   /premises/{premisesId}/lost-beds:
     post:
       tags:
@@ -1424,3 +1459,109 @@ components:
       required:
         - date
         - availableBeds
+    PersonRisks:
+      type: object
+      properties:
+        crn:
+          type: string
+        roshRisks:
+          $ref: '#/components/schemas/RoshRisksEnvelope'
+        mappa:
+          $ref: '#/components/schemas/MappaEnvelope'
+        tier:
+          $ref: '#/components/schemas/RiskTierEnvelope'
+        flags:
+          $ref: '#/components/schemas/FlagsEnvelope'
+      required:
+        - crn
+        - roshRisks
+        - tier
+        - flags
+    RoshRisksEnvelope:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/RiskEnvelopeStatus'
+        value:
+          $ref: '#/components/schemas/RoshRisks'
+      required:
+        - status
+    RoshRisks:
+      type: object
+      properties:
+        overallRisk:
+          type: string
+        riskToChildren:
+          type: string
+        riskToPublic:
+          type: string
+        riskToKnownAdult:
+          type: string
+        riskToStaff:
+          type: string
+        lastUpdated:
+          type: string
+          format: date
+      required:
+        - overallRisk
+        - riskToChildren
+        - riskToPublic
+        - riskToKnownAdult
+        - riskToStaff
+    MappaEnvelope:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/RiskEnvelopeStatus'
+        value:
+          $ref: '#/components/schemas/Mappa'
+      required:
+        - status
+    Mappa:
+      type: object
+      properties:
+        level:
+          type: string
+        lastUpdated:
+          type: string
+          format: date
+      required:
+        - level
+        - lastUpdated
+    RiskTierEnvelope:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/RiskEnvelopeStatus'
+        value:
+          $ref: '#/components/schemas/RiskTier'
+      required:
+        - status
+    RiskTier:
+      type: object
+      properties:
+        level:
+          type: string
+        lastUpdated:
+          type: string
+          format: date
+      required:
+        - level
+        - lastUpdated
+    FlagsEnvelope:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/RiskEnvelopeStatus'
+        value:
+          type: array
+          items:
+            type: string
+      required:
+        - status
+    RiskEnvelopeStatus:
+      type: string
+      enum:
+        - retrieved
+        - not_found
+        - error

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RegistrationClientResponseFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RegistrationClientResponseFactory.kt
@@ -1,0 +1,192 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Registration
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.RegistrationKeyValue
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.RegistrationReview
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.RegistrationStaffHuman
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.time.LocalDate
+
+class RegistrationClientResponseFactory : Factory<Registration> {
+  private var registrationId: Yielded<Long> = { randomInt(1000, 10000).toLong() }
+  private var offenderId: Yielded<Long> = { randomInt(1000, 10000).toLong() }
+  private var register: Yielded<RegistrationKeyValue> = {
+    RegistrationKeyValue("5", "Public Protection")
+  }
+  private var type: Yielded<RegistrationKeyValue> = {
+    RegistrationKeyValue(
+      code = "MAPP",
+      description = "MAPPA"
+    )
+  }
+  private var riskColour: Yielded<String> = { "Red" }
+  private var startDate: Yielded<LocalDate> = { LocalDate.now().minusMonths(5).randomDateBefore(21) }
+  private var nextReviewDate: Yielded<LocalDate> = { LocalDate.now().minusMonths(5).randomDateAfter(21) }
+  private var reviewPerioidMonths: Yielded<Int> = { randomInt(6, 12) }
+  private var notes: Yielded<String?> = { randomStringMultiCaseWithNumbers(8) }
+  private var registeringTeam: Yielded<RegistrationKeyValue> = {
+    RegistrationKeyValue(
+      code = randomStringMultiCaseWithNumbers(5),
+      description = randomStringMultiCaseWithNumbers(10)
+    )
+  }
+  private var registeringOfficer: Yielded<RegistrationStaffHuman> = {
+    RegistrationStaffHuman(
+      code = randomStringMultiCaseWithNumbers(5),
+      forenames = randomStringUpperCase(10),
+      surname = randomStringUpperCase(10)
+    )
+  }
+  private var registeringProbationArea: Yielded<RegistrationKeyValue> = {
+    RegistrationKeyValue(
+      code = randomStringUpperCase(5),
+      description = randomStringUpperCase(20)
+    )
+  }
+  private var registerLevel: Yielded<RegistrationKeyValue?> = {
+    RegistrationKeyValue(
+      code = randomStringUpperCase(5),
+      description = randomStringUpperCase(20)
+    )
+  }
+  private var registerCategory: Yielded<RegistrationKeyValue> = {
+    RegistrationKeyValue(
+      code = "M2",
+      description = "MAPPA Cat 2"
+    )
+  }
+  private var warnUser: Yielded<Boolean> = { false }
+  private var active: Yielded<Boolean> = { true }
+  private var endDate: Yielded<LocalDate?> = { null }
+  private var deregisteringOfficer: Yielded<RegistrationStaffHuman?> = {
+    RegistrationStaffHuman(
+      code = randomStringUpperCase(5),
+      forenames = randomStringUpperCase(5),
+      surname = randomStringUpperCase(5)
+    )
+  }
+  private var deregisteringProbationArea: Yielded<RegistrationKeyValue?> = {
+    RegistrationKeyValue(
+      code = randomStringUpperCase(5),
+      description = randomStringUpperCase(20)
+    )
+  }
+  private var deregisteringNotes: Yielded<String?> = { randomStringUpperCase(10) }
+  private var numberOfPreviousDeregistrations: Yielded<Int> = { 0 }
+  private var registrationReviews: Yielded<List<RegistrationReview>> = { listOf() }
+
+  fun withRegistrationId(registrationId: Long) = apply {
+    this.registrationId = { registrationId }
+  }
+
+  fun withOffenderId(offenderId: Long) = apply {
+    this.offenderId = { offenderId }
+  }
+
+  fun withRegister(register: RegistrationKeyValue) = apply {
+    this.register = { register }
+  }
+
+  fun withType(type: RegistrationKeyValue) = apply {
+    this.type = { type }
+  }
+
+  fun withRiskColour(riskColour: String) = apply {
+    this.riskColour = { riskColour }
+  }
+
+  fun withStartDate(startDate: LocalDate) = apply {
+    this.startDate = { startDate }
+  }
+
+  fun withNextReviewDate(nextReviewDate: LocalDate) = apply {
+    this.nextReviewDate = { nextReviewDate }
+  }
+
+  fun withNotes(notes: String?) = apply {
+    this.notes = { notes }
+  }
+
+  fun withRegisteringTeam(registeringTeam: RegistrationKeyValue) = apply {
+    this.registeringTeam = { registeringTeam }
+  }
+
+  fun withRegisteringOfficer(registeringOfficer: RegistrationStaffHuman) = apply {
+    this.registeringOfficer = { registeringOfficer }
+  }
+
+  fun withRegisteringProbationArea(registeringProbationArea: RegistrationKeyValue) = apply {
+    this.registeringProbationArea = { registeringProbationArea }
+  }
+
+  fun withRegisterLevel(registerLevel: RegistrationKeyValue?) = apply {
+    this.registerLevel = { registerLevel }
+  }
+
+  fun withRegisterCategory(registerCategory: RegistrationKeyValue) = apply {
+    this.registerCategory = { registerCategory }
+  }
+
+  fun withWarnUser(warnUser: Boolean) = apply {
+    this.warnUser = { warnUser }
+  }
+
+  fun withActive(active: Boolean) = apply {
+    this.active = { active }
+  }
+
+  fun withEndDate(endDate: LocalDate) = apply {
+    this.endDate = { endDate }
+  }
+
+  fun withDeregisteringOfficer(deregisteringOfficer: RegistrationStaffHuman?) = apply {
+    this.deregisteringOfficer = { deregisteringOfficer }
+  }
+
+  fun withDeregisteringProbationArea(deregisteringProbationArea: RegistrationKeyValue?) = apply {
+    this.deregisteringProbationArea = { deregisteringProbationArea }
+  }
+
+  fun withDeregisteringNotes(deregisteringNotes: String?) = apply {
+    this.deregisteringNotes = { deregisteringNotes }
+  }
+
+  fun withNumberOfPreviousDeregistrations(numberOfPreviousDeregistrations: Int) = apply {
+    this.numberOfPreviousDeregistrations = { numberOfPreviousDeregistrations }
+  }
+
+  fun withRegistrationReviews(registrationReviews: List<RegistrationReview>) = apply {
+    this.registrationReviews = { registrationReviews }
+  }
+
+  override fun produce() = Registration(
+    registrationId = this.registrationId(),
+    offenderId = this.offenderId(),
+    register = this.register(),
+    type = this.type(),
+    riskColour = this.riskColour(),
+    startDate = this.startDate(),
+    nextReviewDate = this.nextReviewDate(),
+    reviewPeriodMonths = this.reviewPerioidMonths(),
+    notes = this.notes(),
+    registeringTeam = this.registeringTeam(),
+    registeringOfficer = this.registeringOfficer(),
+    registeringProbationArea = this.registeringProbationArea(),
+    registerLevel = this.registerLevel(),
+    registerCategory = this.registerCategory(),
+    warnUser = this.warnUser(),
+    active = this.active(),
+    endDate = this.endDate(),
+    deregisteringOfficer = this.deregisteringOfficer(),
+    deregisteringProbationArea = this.deregisteringProbationArea(),
+    deregisteringNotes = this.deregisteringNotes(),
+    numberOfPreviousDeregistrations = this.numberOfPreviousDeregistrations(),
+    registrationReviews = this.registrationReviews()
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RoshRisksClientResponseFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RoshRisksClientResponseFactory.kt
@@ -1,0 +1,92 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.assessrisksandneeds.OtherRoshRisks
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.assessrisksandneeds.Response
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.assessrisksandneeds.Risk
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.assessrisksandneeds.RoshRiskToSelf
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.assessrisksandneeds.RoshRisks
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.assessrisksandneeds.RoshRisksSummary
+import java.time.LocalDateTime
+
+class RoshRisksClientResponseFactory : Factory<RoshRisks> {
+  private var roshRiskToSelf: Yielded<RoshRiskToSelf> = {
+    RoshRiskToSelf(
+      suicide = Risk(
+        risk = Response.NO,
+        previous = null,
+        previousConcernsText = null,
+        current = Response.NO,
+        currentConcernsText = null
+      ),
+      custody = Risk(
+        risk = Response.NO,
+        previous = null,
+        previousConcernsText = null,
+        current = Response.NO,
+        currentConcernsText = null
+      ),
+      hostelSetting = Risk(
+        risk = Response.NO,
+        previous = null,
+        previousConcernsText = null,
+        current = Response.NO,
+        currentConcernsText = null
+      ),
+      vulnerability = Risk(
+        risk = Response.NO,
+        previous = null,
+        previousConcernsText = null,
+        current = Response.NO,
+        currentConcernsText = null
+      ),
+      assessedOn = LocalDateTime.now()
+    )
+  }
+
+  private var otherRoshRisks: Yielded<OtherRoshRisks> = {
+    OtherRoshRisks(
+      escapeOrAbscond = Response.NO,
+      controlIssuesDisruptiveBehaviour = Response.NO,
+      breachOfTrust = Response.NO,
+      riskToOtherPrisoners = Response.NO,
+      assessedOn = LocalDateTime.now()
+    )
+  }
+
+  private var summary: Yielded<RoshRisksSummary> = {
+    RoshRisksSummary(
+      whoIsAtRisk = null,
+      natureOfRisk = null,
+      riskImminence = null,
+      riskIncreaseFactors = null,
+      riskMitigationFactors = null,
+      riskInCommunity = mapOf(),
+      riskInCustody = mapOf(),
+      assessedOn = null,
+      overallRiskLevel = null
+    )
+  }
+
+  private var assessedOn: Yielded<LocalDateTime?> = { LocalDateTime.now() }
+
+  fun withRiskToSelf(roshRiskToSelf: RoshRiskToSelf) = apply {
+    this.roshRiskToSelf = { roshRiskToSelf }
+  }
+
+  fun withOtherRoshRisks(otherRoshRisks: OtherRoshRisks) = apply {
+    this.otherRoshRisks = { otherRoshRisks }
+  }
+
+  fun withSummary(summary: RoshRisksSummary) = apply {
+    this.summary = { summary }
+  }
+
+  override fun produce() = RoshRisks(
+    riskToSelf = this.roshRiskToSelf(),
+    otherRisks = this.otherRoshRisks(),
+    summary = this.summary(),
+    assessedOn = this.assessedOn()
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonRisksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonRisksTest.kt
@@ -1,0 +1,242 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FlagsEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Mappa
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MappaEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonRisks
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RiskEnvelopeStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RiskTier
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RiskTierEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RoshRisks
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RoshRisksEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RegistrationClientResponseFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshRisksClientResponseFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.assessrisksandneeds.RiskLevel
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.assessrisksandneeds.RoshRisksSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.RegistrationKeyValue
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Registrations
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.hmppstier.Tier
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+class PersonRisksTest : IntegrationTestBase() {
+  @Test
+  fun `Getting risks by CRN without a JWT returns 401`() {
+    webTestClient.get()
+      .uri("/person/CRN/risks")
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `Getting risks for a CRN with a non-Delius JWT returns 403`() {
+    val jwt = jwtAuthHelper.createClientCredentialsJwt(
+      username = "username",
+      authSource = "nomis"
+    )
+
+    webTestClient.get()
+      .uri("/person/CRN/risks")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `Getting risks for a CRN without ROLE_PROBATION returns 403`() {
+    val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
+      subject = "username",
+      authSource = "delius"
+    )
+
+    webTestClient.get()
+      .uri("/person/CRN/risks")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `Getting risks for a CRN that does not exist returns 404`() {
+    mockClientCredentialsJwtRequest(username = "username", authSource = "delius")
+
+    wiremockServer.stubFor(
+      get(WireMock.urlEqualTo("/secure/offenders/crn/CRN"))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(404)
+        )
+    )
+
+    val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
+      subject = "username",
+      authSource = "delius",
+      roles = listOf("ROLE_PROBATION")
+    )
+
+    webTestClient.get()
+      .uri("/person/CRN/risks")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isNotFound
+  }
+
+  @Test
+  fun `Getting risks for a CRN returns OK with correct body`() {
+    mockClientCredentialsJwtRequest(username = "username", authSource = "delius")
+
+    wiremockServer.stubFor(
+      get(WireMock.urlEqualTo("/secure/offenders/crn/CRN"))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(200)
+            .withBody(
+              objectMapper.writeValueAsString(
+                OffenderDetailsSummaryFactory()
+                  .withCrn("CRN")
+                  .withFirstName("James")
+                  .withLastName("Someone")
+                  .produce()
+              )
+            )
+        )
+    )
+
+    wiremockServer.stubFor(
+      get(WireMock.urlEqualTo("/risks/crn/CRN"))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(200)
+            .withBody(
+              objectMapper.writeValueAsString(
+                RoshRisksClientResponseFactory().withSummary(
+                  RoshRisksSummary(
+                    whoIsAtRisk = null,
+                    natureOfRisk = null,
+                    riskImminence = null,
+                    riskIncreaseFactors = null,
+                    riskMitigationFactors = null,
+                    riskInCommunity = mapOf(
+                      RiskLevel.LOW to listOf("Children"),
+                      RiskLevel.MEDIUM to listOf("Public"),
+                      RiskLevel.HIGH to listOf("Known Adult"),
+                      RiskLevel.VERY_HIGH to listOf("Staff")
+                    ),
+                    riskInCustody = mapOf(),
+                    assessedOn = LocalDateTime.parse("2022-09-06T13:45:00"),
+                    overallRiskLevel = RiskLevel.MEDIUM
+                  )
+                ).produce()
+              )
+            )
+        )
+    )
+
+    wiremockServer.stubFor(
+      get(WireMock.urlEqualTo("/crn/CRN/tier"))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(200)
+            .withBody(
+              objectMapper.writeValueAsString(
+                Tier(
+                  tierScore = "M2",
+                  calculationId = UUID.randomUUID(),
+                  calculationDate = LocalDateTime.parse("2022-09-06T14:59:00")
+                )
+              )
+            )
+        )
+    )
+
+    wiremockServer.stubFor(
+      get(WireMock.urlEqualTo("/secure/offenders/crn/CRN/registrations?activeOnly=true"))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(200)
+            .withBody(
+              objectMapper.writeValueAsString(
+                Registrations(
+                  registrations = listOf(
+                    RegistrationClientResponseFactory()
+                      .withType(RegistrationKeyValue(code = "MAPP", description = "MAPPA"))
+                      .withRegisterCategory(RegistrationKeyValue(code = "C1", description = "C1"))
+                      .withRegisterLevel(RegistrationKeyValue(code = "L1", description = "L1"))
+                      .withStartDate(LocalDate.parse("2022-09-06"))
+                      .produce(),
+                    RegistrationClientResponseFactory()
+                      .withType(RegistrationKeyValue(code = "FLAG", description = "RISK FLAG"))
+                      .produce()
+                  )
+                )
+              )
+            )
+        )
+    )
+
+    val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
+      subject = "username",
+      authSource = "delius",
+      roles = listOf("ROLE_PROBATION")
+    )
+
+    webTestClient.get()
+      .uri("/person/CRN/risks")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .json(
+        objectMapper.writeValueAsString(
+          PersonRisks(
+            crn = "CRN",
+            roshRisks = RoshRisksEnvelope(
+              status = RiskEnvelopeStatus.retrieved,
+              value = RoshRisks(
+                overallRisk = "Medium",
+                riskToChildren = "Low",
+                riskToPublic = "Medium",
+                riskToKnownAdult = "High",
+                riskToStaff = "Very High",
+                lastUpdated = LocalDate.parse("2022-09-06")
+              )
+            ),
+            tier = RiskTierEnvelope(
+              status = RiskEnvelopeStatus.retrieved,
+              value = RiskTier(
+                level = "M2",
+                lastUpdated = LocalDate.parse("2022-09-06")
+              )
+            ),
+            flags = FlagsEnvelope(
+              status = RiskEnvelopeStatus.retrieved,
+              value = listOf("RISK FLAG")
+            ),
+            mappa = MappaEnvelope(
+              status = RiskEnvelopeStatus.retrieved,
+              value = Mappa(
+                level = "CAT C1/LEVEL L1",
+                lastUpdated = LocalDate.parse("2022-09-06")
+              )
+            )
+          )
+        )
+      )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
@@ -6,18 +6,38 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.AssessRisksAndNeedsApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.HMPPSTierApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RegistrationClientResponseFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshRisksClientResponseFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.assessrisksandneeds.RiskLevel
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.assessrisksandneeds.RoshRisks
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.assessrisksandneeds.RoshRisksSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.RegistrationKeyValue
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Registrations
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.UserOffenderAccess
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.hmppstier.Tier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import java.lang.RuntimeException
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
 
 class OffenderServiceTest {
   private val mockCommunityApiClient = mockk<CommunityApiClient>()
+  private val mockAssessRisksAndNeedsApiClient = mockk<AssessRisksAndNeedsApiClient>()
+  private val mockHMPPSTierApiClient = mockk<HMPPSTierApiClient>()
 
-  private val offenderService = OffenderService(mockCommunityApiClient)
+  private val offenderService = OffenderService(
+    mockCommunityApiClient,
+    mockAssessRisksAndNeedsApiClient,
+    mockHMPPSTierApiClient
+  )
 
   @Test
   fun `getOffenderByCrn returns NotFound result when Client returns 404`() {
@@ -111,4 +131,190 @@ class OffenderServiceTest {
     assertThat(result.entity.firstName).isEqualTo("Bob")
     assertThat(result.entity.surname).isEqualTo("Doe")
   }
+
+  @Test
+  fun `getRisksByCrn returns NotFound result when Community API Client returns 404`() {
+    every { mockCommunityApiClient.getOffenderDetailSummary("a-crn") } returns ClientResult.StatusCodeFailure(HttpStatus.NOT_FOUND, null)
+
+    assertThat(offenderService.getRiskByCrn("a-crn", "jwt", "distinguished.name") is AuthorisableActionResult.NotFound).isTrue
+  }
+
+  @Test
+  fun `getRisksByCrn throws when Community API Client returns other non-2xx status code`() {
+    every { mockCommunityApiClient.getOffenderDetailSummary("a-crn") } returns ClientResult.StatusCodeFailure(HttpStatus.BAD_REQUEST, null)
+
+    val exception = assertThrows<RuntimeException> { offenderService.getRiskByCrn("a-crn", "jwt", "distinguished.name") }
+    assertThat(exception.message).isEqualTo("Unable to complete request: 400 BAD_REQUEST")
+  }
+
+  @Test
+  fun `getRisksByCrn returns Unauthorised result when distinguished name is excluded from viewing`() {
+    val resultBody = OffenderDetailsSummaryFactory()
+      .withCrn("a-crn")
+      .withFirstName("Bob")
+      .withLastName("Doe")
+      .withCurrentExclusion(true)
+      .produce()
+
+    val accessBody = UserOffenderAccess(userRestricted = false, userExcluded = true)
+
+    every { mockCommunityApiClient.getOffenderDetailSummary("a-crn") } returns ClientResult.Success(HttpStatus.OK, resultBody)
+    every { mockCommunityApiClient.getUserAccessForOffenderCrn("distinguished.name", "a-crn") } returns ClientResult.Success(HttpStatus.OK, accessBody)
+
+    assertThat(offenderService.getRiskByCrn("a-crn", "jwt", "distinguished.name") is AuthorisableActionResult.Unauthorised).isTrue
+  }
+
+  @Test
+  fun `getRisksByCrn returns NotFound envelopes for RoSH, Tier, Mappa & flags when respective Clients return 404`() {
+    val crn = "a-crn"
+    val jwt = "jwt"
+    val distinguishedName = "distinguished.name"
+
+    mockExistingNonLaoOffender()
+    mock404RoSH(crn, jwt)
+    mock404Tier(crn)
+    mock404Registrations(crn)
+
+    val result = offenderService.getRiskByCrn(crn, jwt, distinguishedName)
+    assertThat(result is AuthorisableActionResult.Success).isTrue
+    result as AuthorisableActionResult.Success
+    assertThat(result.entity.crn).isEqualTo(crn)
+    assertThat(result.entity.roshRisks.status).isEqualTo(RiskStatus.NotFound)
+    assertThat(result.entity.tier.status).isEqualTo(RiskStatus.NotFound)
+    assertThat(result.entity.mappa.status).isEqualTo(RiskStatus.NotFound)
+    assertThat(result.entity.flags.status).isEqualTo(RiskStatus.NotFound)
+  }
+
+  @Test
+  fun `getRisksByCrn returns Error envelopes for RoSH, Tier, Mappa & flags when respective Clients return 500`() {
+    val crn = "a-crn"
+    val jwt = "jwt"
+    val distinguishedName = "distinguished.name"
+
+    mockExistingNonLaoOffender()
+    mock500RoSH(crn, jwt)
+    mock500Tier(crn)
+    mock500Registrations(crn)
+
+    val result = offenderService.getRiskByCrn(crn, jwt, distinguishedName)
+    assertThat(result is AuthorisableActionResult.Success).isTrue
+    result as AuthorisableActionResult.Success
+    assertThat(result.entity.crn).isEqualTo(crn)
+    assertThat(result.entity.roshRisks.status).isEqualTo(RiskStatus.Error)
+    assertThat(result.entity.tier.status).isEqualTo(RiskStatus.Error)
+    assertThat(result.entity.mappa.status).isEqualTo(RiskStatus.Error)
+    assertThat(result.entity.flags.status).isEqualTo(RiskStatus.Error)
+  }
+
+  @Test
+  fun `getRisksByCrn returns Retrieved envelopes with expected contents for RoSH, Tier, Mappa & flags when respective Clients return 200`() {
+    val crn = "a-crn"
+    val jwt = "jwt"
+    val distinguishedName = "distinguished.name"
+
+    mockExistingNonLaoOffender()
+
+    mock200RoSH(
+      crn,
+      jwt,
+      RoshRisksClientResponseFactory().withSummary(
+        RoshRisksSummary(
+          whoIsAtRisk = null,
+          natureOfRisk = null,
+          riskImminence = null,
+          riskIncreaseFactors = null,
+          riskMitigationFactors = null,
+          riskInCommunity = mapOf(
+            RiskLevel.LOW to listOf("Children"),
+            RiskLevel.MEDIUM to listOf("Public"),
+            RiskLevel.HIGH to listOf("Known Adult"),
+            RiskLevel.VERY_HIGH to listOf("Staff")
+          ),
+          riskInCustody = mapOf(),
+          assessedOn = LocalDateTime.parse("2022-09-06T13:45:00"),
+          overallRiskLevel = RiskLevel.MEDIUM
+        )
+      ).produce()
+    )
+
+    mock200Tier(
+      crn,
+      Tier(
+        tierScore = "M2",
+        calculationId = UUID.randomUUID(),
+        calculationDate = LocalDateTime.parse("2022-09-06T14:59:00")
+      )
+    )
+
+    mock200Registrations(
+      crn,
+      Registrations(
+        registrations = listOf(
+          RegistrationClientResponseFactory()
+            .withType(RegistrationKeyValue(code = "MAPP", description = "MAPPA"))
+            .withRegisterCategory(RegistrationKeyValue(code = "C1", description = "C1"))
+            .withRegisterLevel(RegistrationKeyValue(code = "L1", description = "L1"))
+            .withStartDate(LocalDate.parse("2022-09-06"))
+            .produce(),
+          RegistrationClientResponseFactory()
+            .withType(RegistrationKeyValue(code = "FLAG", description = "RISK FLAG"))
+            .produce()
+        )
+      )
+    )
+
+    val result = offenderService.getRiskByCrn(crn, jwt, distinguishedName)
+    assertThat(result is AuthorisableActionResult.Success).isTrue
+    result as AuthorisableActionResult.Success
+    assertThat(result.entity.crn).isEqualTo(crn)
+
+    assertThat(result.entity.roshRisks.status).isEqualTo(RiskStatus.Retrieved)
+    result.entity.roshRisks.value!!.let {
+      assertThat(it.lastUpdated).isEqualTo(LocalDate.parse("2022-09-06"))
+      assertThat(it.overallRisk).isEqualTo("Medium")
+      assertThat(it.riskToChildren).isEqualTo("Low")
+      assertThat(it.riskToPublic).isEqualTo("Medium")
+      assertThat(it.riskToKnownAdult).isEqualTo("High")
+      assertThat(it.riskToStaff).isEqualTo("Very High")
+    }
+
+    assertThat(result.entity.tier.status).isEqualTo(RiskStatus.Retrieved)
+    result.entity.tier.value!!.let {
+      assertThat(it.lastUpdated).isEqualTo(LocalDate.parse("2022-09-06"))
+      assertThat(it.level).isEqualTo("M2")
+    }
+
+    assertThat(result.entity.mappa.status).isEqualTo(RiskStatus.Retrieved)
+    result.entity.mappa.value!!.let {
+      assertThat(it.lastUpdated).isEqualTo(LocalDate.parse("2022-09-06"))
+      assertThat(it.level).isEqualTo("CAT C1/LEVEL L1")
+    }
+
+    assertThat(result.entity.flags.status).isEqualTo(RiskStatus.Retrieved)
+    assertThat(result.entity.flags.value).contains("RISK FLAG")
+  }
+
+  private fun mockExistingNonLaoOffender() {
+    val resultBody = OffenderDetailsSummaryFactory()
+      .withCrn("a-crn")
+      .withFirstName("Bob")
+      .withLastName("Doe")
+      .withCurrentRestriction(false)
+      .withCurrentExclusion(false)
+      .produce()
+
+    every { mockCommunityApiClient.getOffenderDetailSummary("a-crn") } returns ClientResult.Success(HttpStatus.OK, resultBody)
+  }
+
+  private fun mock404RoSH(crn: String, jwt: String) = every { mockAssessRisksAndNeedsApiClient.getRoshRisks(crn, jwt) } returns ClientResult.StatusCodeFailure(HttpStatus.NOT_FOUND, body = null)
+  private fun mock404Tier(crn: String) = every { mockHMPPSTierApiClient.getTier(crn) } returns ClientResult.StatusCodeFailure(HttpStatus.NOT_FOUND, body = null)
+  private fun mock404Registrations(crn: String) = every { mockCommunityApiClient.getRegistrationsForOffenderCrn(crn) } returns ClientResult.StatusCodeFailure(HttpStatus.NOT_FOUND, body = null)
+
+  private fun mock500RoSH(crn: String, jwt: String) = every { mockAssessRisksAndNeedsApiClient.getRoshRisks(crn, jwt) } returns ClientResult.StatusCodeFailure(HttpStatus.INTERNAL_SERVER_ERROR, body = null)
+  private fun mock500Tier(crn: String) = every { mockHMPPSTierApiClient.getTier(crn) } returns ClientResult.StatusCodeFailure(HttpStatus.INTERNAL_SERVER_ERROR, body = null)
+  private fun mock500Registrations(crn: String) = every { mockCommunityApiClient.getRegistrationsForOffenderCrn(crn) } returns ClientResult.StatusCodeFailure(HttpStatus.INTERNAL_SERVER_ERROR, body = null)
+
+  private fun mock200RoSH(crn: String, jwt: String, body: RoshRisks) = every { mockAssessRisksAndNeedsApiClient.getRoshRisks(crn, jwt) } returns ClientResult.Success(HttpStatus.OK, body = body)
+  private fun mock200Tier(crn: String, body: Tier) = every { mockHMPPSTierApiClient.getTier(crn) } returns ClientResult.Success(HttpStatus.OK, body = body)
+  private fun mock200Registrations(crn: String, body: Registrations) = every { mockCommunityApiClient.getRegistrationsForOffenderCrn(crn) } returns ClientResult.Success(HttpStatus.OK, body = body)
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -34,3 +34,5 @@ hmpps:
 services:
   community-api:
     base-url: http://localhost:57839
+  assess-risks-and-needs-api:
+    base-url: http://localhost:57839

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -24,6 +24,12 @@ spring:
             client-secret: clientsecret
             client-authentication-method: client_secret_jwt
             authorization-grant-type: client_credentials
+          hmpps-tier:
+            provider: hmpps-auth
+            client-id: approved-premises-api
+            client-secret: clientsecret
+            client-authentication-method: client_secret_jwt
+            authorization-grant-type: client_credentials
 
 hmpps:
   auth:
@@ -35,4 +41,6 @@ services:
   community-api:
     base-url: http://localhost:57839
   assess-risks-and-needs-api:
+    base-url: http://localhost:57839
+  hmpps-tier:
     base-url: http://localhost:57839

--- a/wiremock/mappings/AssessmentApi_GetLatestCompletedAssessmentNeeds.json
+++ b/wiremock/mappings/AssessmentApi_GetLatestCompletedAssessmentNeeds.json
@@ -1,0 +1,106 @@
+{
+  "id": "3e862519-78b0-4449-b2b5-535ee1b81213",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/assessments/crn/X123456/needs/latest?period=YEAR&periodUnits=1"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody":
+    {
+      "needs": [
+        {
+          "section": "ACCOMMODATION",
+          "name": "Accommodation",
+          "overThreshold": false,
+          "riskOfHarm": true,
+          "riskOfReoffending": true,
+          "flaggedAsNeed": false,
+          "severity": "SEVERE",
+          "identifiedAsNeed": true,
+          "needScore" : 2
+        },
+        {
+          "section": "EDUCATION_TRAINING_AND_EMPLOYABILITY",
+          "name": "4 - Education, Training and Employability",
+          "overThreshold": false,
+          "riskOfHarm": true,
+          "riskOfReoffending": true,
+          "flaggedAsNeed": false,
+          "severity": "SEVERE",
+          "identifiedAsNeed": true,
+          "needScore" : 2
+        },
+        {
+          "section": "FINANCIAL_MANAGEMENT_AND_INCOME",
+          "name": "Financial Management and Income",
+          "overThreshold": false,
+          "riskOfHarm": false,
+          "riskOfReoffending": false,
+          "flaggedAsNeed": false,
+          "severity": "NO_NEED",
+          "identifiedAsNeed": false
+        },
+        {
+          "section": "RELATIONSHIPS",
+          "name": "Relationships",
+          "overThreshold": false,
+          "riskOfHarm": true,
+          "riskOfReoffending": true,
+          "flaggedAsNeed": false,
+          "severity": "SEVERE",
+          "identifiedAsNeed": true,
+          "needScore" : 2
+        },
+        {
+          "section": "LIFESTYLE_AND_ASSOCIATES",
+          "name": "Lifestyle and Associates",
+          "overThreshold": false,
+          "riskOfHarm": true,
+          "riskOfReoffending": true,
+          "flaggedAsNeed": false,
+          "severity": "SEVERE",
+          "identifiedAsNeed": true,
+          "needScore" : 2
+        },
+        {
+          "section": "DRUG_MISUSE",
+          "name": "Drug Misuse",
+          "overThreshold": false,
+          "riskOfHarm": true,
+          "riskOfReoffending": true,
+          "flaggedAsNeed": false,
+          "severity": "SEVERE",
+          "identifiedAsNeed": true,
+          "needScore" : 2
+        },
+        {
+          "section": "ALCOHOL_MISUSE",
+          "name": "Alcohol Misuse",
+          "overThreshold": false,
+          "riskOfHarm": true,
+          "riskOfReoffending": true,
+          "flaggedAsNeed": false,
+          "severity": "SEVERE",
+          "identifiedAsNeed": true,
+          "needScore" : 2
+        },
+        {
+          "section": "EMOTIONAL_WELL_BEING",
+          "name": "Emotional Well-Being",
+          "overThreshold": false,
+          "riskOfHarm": false,
+          "riskOfReoffending": false,
+          "flaggedAsNeed": false,
+          "severity": "NO_NEED",
+          "identifiedAsNeed": false
+        }
+      ],
+      "assessedOn": "2021-06-21T15:55:04",
+      "historicStatus": "CURRENT"
+    }
+  }
+}

--- a/wiremock/mappings/AssessmentApi_GetLatestCompletedAssessmentRoshSectionAnswers.json
+++ b/wiremock/mappings/AssessmentApi_GetLatestCompletedAssessmentRoshSectionAnswers.json
@@ -1,0 +1,317 @@
+{
+  "id": "3e862519-78b0-4449-b2b5-535ee1b81213",
+  "request": {
+    "method": "POST",
+    "urlPathPattern": "/assessments/crn/(.*)/sections/answers*"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+      "assessmentId": 9479348,
+      "sections": {
+        "ROSH": [
+          {
+            "refQuestionCode": "R2.1",
+            "questionText": "Is the offender, now or on release, likely to live with, or have frequent contact with, any child who is on the child protection register or is being looked after by the local authority.",
+            "refAnswerCode": "YES",
+            "staticText": "Yes"
+          },
+          {
+            "refQuestionCode": "R2.2",
+            "questionText": "Are there any concerns in relation to children",
+            "refAnswerCode": "YES",
+            "staticText": "Yes"
+          },
+          {
+            "refQuestionCode": "R2.2.1",
+            "questionText": "Should contact be made with social services",
+            "refAnswerCode": "YES",
+            "staticText": "Yes"
+          },
+          {
+            "refQuestionCode": "R3.1",
+            "questionText": "Risk of suicide",
+            "refAnswerCode": "NO",
+            "staticText": "No"
+          },
+          {
+            "refQuestionCode": "R3.2",
+            "questionText": "Risk of self-harm",
+            "refAnswerCode": "YES",
+            "staticText": "Yes"
+          },
+          {
+            "refQuestionCode": "R3.3",
+            "questionText": "Coping in custody / hostel setting",
+            "refAnswerCode": "YES",
+            "staticText": "Yes"
+          },
+          {
+            "refQuestionCode": "R3.4",
+            "questionText": "Vulnerability",
+            "refAnswerCode": "YES",
+            "staticText": "Yes"
+          },
+          {
+            "refQuestionCode": "R4.1",
+            "questionText": "Escape / abscond",
+            "refAnswerCode": "YES",
+            "staticText": "Yes"
+          },
+          {
+            "refQuestionCode": "R4.2",
+            "questionText": "Control issues / disruptive behaviour",
+            "refAnswerCode": "YES",
+            "staticText": "Yes"
+          },
+          {
+            "refQuestionCode": "R4.3",
+            "questionText": "Concerns in respect of breach of trust",
+            "refAnswerCode": "DK",
+            "staticText": "Don't know"
+          },
+          {
+            "refQuestionCode": "R4.4",
+            "questionText": "Risks to other prisoners",
+            "refAnswerCode": "YES",
+            "staticText": "Yes"
+          }
+        ],
+        "ROSHFULL": [
+          {
+            "refQuestionCode": "FA1",
+            "questionText": "Offence details",
+            "freeFormText": "shjkhsdjhkjshfkjshdkfjhskjdhkjhkjhkj"
+          },
+          {
+            "refQuestionCode": "FA16",
+            "questionText": "b) is involved in a situation where there are identifiable children who are considered to be at risk from others",
+            "refAnswerCode": "YES",
+            "staticText": "Yes"
+          },
+          {
+            "refQuestionCode": "FA2",
+            "questionText": "Where and when did s/he do it",
+            "freeFormText": "klsdjkljlksd"
+          },
+          {
+            "refQuestionCode": "FA3",
+            "questionText": "How did s/he do it (was there any pre planning, use of weapon, tool etc)",
+            "freeFormText": "sdlljsd;ljf;lds"
+          },
+          {
+            "refQuestionCode": "FA31",
+            "questionText": "Are there any current concerns about suicide",
+            "refAnswerCode": "YES",
+            "staticText": "Yes"
+          },
+          {
+            "refQuestionCode": "FA32",
+            "questionText": "Are there any current concerns about self-harm",
+            "refAnswerCode": "YES",
+            "staticText": "Yes"
+          },
+          {
+            "refQuestionCode": "FA33",
+            "questionText": "Describe circumstances, relevant issues and needs regarding current concerns (refer to sections 1-12 for indicators, particularly Section 10)",
+            "freeFormText": "Suicide and/or Self-harm current concerns"
+          },
+          {
+            "refQuestionCode": "FA34",
+            "questionText": "Is there a current ACCT (Assessment, Care in Custody and Teamwork?)",
+            "refAnswerCode": "YES",
+            "staticText": "Yes"
+          },
+          {
+            "refQuestionCode": "FA36",
+            "questionText": "Have there been any concerns about suicide in the past",
+            "refAnswerCode": "YES",
+            "staticText": "Yes"
+          },
+          {
+            "refQuestionCode": "FA37",
+            "questionText": "Have there been any concerns about self-harm in the past",
+            "refAnswerCode": "YES",
+            "staticText": "Yes"
+          },
+          {
+            "refQuestionCode": "FA39",
+            "questionText": "Are there any current concerns about coping in custody",
+            "refAnswerCode": "YES",
+            "staticText": "Yes"
+          },
+          {
+            "refQuestionCode": "FA4",
+            "questionText": "Who were the victims (are there concerns about targeting, type, age, race of vulnerability or victim)",
+            "freeFormText": "sdflkl;sdkjf;l"
+          },
+          {
+            "refQuestionCode": "FA40",
+            "questionText": "Are there any current concerns about coping in hostel settings",
+            "refAnswerCode": "NO",
+            "staticText": "No"
+          },
+          {
+            "refQuestionCode": "FA41",
+            "questionText": "Describe circumstances, relevant issues and needs",
+            "freeFormText": "Coping in custody / hostel setting current concerns"
+          },
+          {
+            "refQuestionCode": "FA42",
+            "questionText": "Are there any previous concerns about coping in custody",
+            "refAnswerCode": "YES",
+            "staticText": "Yes"
+          },
+          {
+            "refQuestionCode": "FA43",
+            "questionText": "Are there any previous concerns about coping in hostel settings",
+            "refAnswerCode": "NO",
+            "staticText": "No"
+          },
+          {
+            "refQuestionCode": "FA44",
+            "questionText": "Describe circumstances, relevant issues and needs",
+            "freeFormText": "Coping in custody / hostel setting previous concerns"
+          },
+          {
+            "refQuestionCode": "FA45",
+            "questionText": "Are there any current concerns about vulnerability (eg victimisation, being bullied, assaulted, exploited)",
+            "refAnswerCode": "YES",
+            "staticText": "Yes"
+          },
+          {
+            "refQuestionCode": "FA45.t",
+            "questionText": "Describe circumstances, relevant issues and needs",
+            "freeFormText": "Vulnerability current concerns free text"
+          },
+          {
+            "refQuestionCode": "FA47",
+            "questionText": "Have there been any previous concerns about vulnerability (eg victimisation, being bullied, assaulted, exploited)",
+            "refAnswerCode": "YES",
+            "staticText": "Yes"
+          },
+          {
+            "refQuestionCode": "FA47.t",
+            "questionText": "Describe circumstances, relevant issues and needs",
+            "freeFormText": "Vulnerability previous concerns free text"
+          },
+          {
+            "refQuestionCode": "FA49",
+            "questionText": " Do any of the above (R8.1 - 8.3) indicate a risk of serious harm to others.  If YES complete the risk of serious harm analysis, R6",
+            "refAnswerCode": "YES",
+            "staticText": "Yes"
+          },
+          {
+            "refQuestionCode": "FA49.t",
+            "questionText": "Describe circumstances, relevant issues and needs",
+            "freeFormText": "Risk of serious harm free text"
+          },
+          {
+            "refQuestionCode": "FA5",
+            "questionText": "Was anyone else present / involved",
+            "freeFormText": "sflk;ljkf;lds"
+          },
+          {
+            "refQuestionCode": "FA6",
+            "questionText": "Why did s/he do it (motivation and triggers)",
+            "freeFormText": "sfkjlj"
+          },
+          {
+            "refQuestionCode": "FA7",
+            "questionText": "Sources of information",
+            "freeFormText": "fshjkjhk"
+          }
+        ],
+        "ROSHSUM": [
+          {
+            "refQuestionCode": "SUM1",
+            "questionText": "Who is at risk",
+            "freeFormText": "whoisAtRisk"
+          },
+          {
+            "refQuestionCode": "SUM2",
+            "questionText": "What is the nature of the risk",
+            "freeFormText": "natureOfRisk"
+          },
+          {
+            "refQuestionCode": "SUM3",
+            "questionText": "When is the risk likely to be greatest\nConsider the timescale and indicate whether risk is immediate or not.  Consider the risks in custody as well as on release.\n",
+            "freeFormText": "riskImminence"
+          },
+          {
+            "refQuestionCode": "SUM4",
+            "questionText": "What circumstances are likely to increase risk\nDescribe factors, actions, events which might increase level of risk, now and in the future\n",
+            "freeFormText": "riskIncreaseFactors"
+          },
+          {
+            "refQuestionCode": "SUM5",
+            "questionText": "What factors are likely to reduce the risk\nDescribe factors, actions, and events which may reduce or contain the level of risk. What has previously stopped him / her?  ",
+            "freeFormText": "riskMitigationFactors"
+          },
+          {
+            "refQuestionCode": "SUM6.1.1",
+            "questionText": "Risk in Community",
+            "refAnswerCode": "L",
+            "staticText": "Low"
+          },
+          {
+            "refQuestionCode": "SUM6.1.2",
+            "questionText": "Risk in Custody",
+            "refAnswerCode": "L",
+            "staticText": "Low"
+          },
+          {
+            "refQuestionCode": "SUM6.2.1",
+            "questionText": "Risk in Community",
+            "refAnswerCode": "M",
+            "staticText": "Medium"
+          },
+          {
+            "refQuestionCode": "SUM6.2.2",
+            "questionText": "Risk in Custody",
+            "refAnswerCode": "L",
+            "staticText": "Low"
+          },
+          {
+            "refQuestionCode": "SUM6.3.1",
+            "questionText": "Risk in Community",
+            "refAnswerCode": "L",
+            "staticText": "Low"
+          },
+          {
+            "refQuestionCode": "SUM6.3.2",
+            "questionText": "Risk in Custody",
+            "refAnswerCode": "L",
+            "staticText": "Low"
+          },
+          {
+            "refQuestionCode": "SUM6.4.1",
+            "questionText": "Risk in Community",
+            "refAnswerCode": "H",
+            "staticText": "High"
+          },
+          {
+            "refQuestionCode": "SUM6.4.2",
+            "questionText": "Risk in Custody",
+            "refAnswerCode": "V",
+            "staticText": "Very High"
+          },
+          {
+            "refQuestionCode": "SUM6.5.2",
+            "questionText": "Risk in Custody",
+            "refAnswerCode": "H",
+            "staticText": "High"
+          },
+          {
+            "refQuestionCode": "SUM8",
+            "questionText": "If necessary record the details of any key documents or reports used in this analysis:",
+            "freeFormText": "zccx"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/wiremock/mappings/HMPPSTier_GetTierForCrn.json
+++ b/wiremock/mappings/HMPPSTier_GetTierForCrn.json
@@ -1,0 +1,18 @@
+{
+  "id": "05c36ca3-f66c-4ffe-917e-65aff9567af1",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/crn/(.*)/tier"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+      "tierScore": "D2",
+      "calculationId": "734996bc-ae5f-44a5-8925-3428492846c3",
+      "calculationDate": "2022-09-05T10:19:00"
+    }
+  }
+}


### PR DESCRIPTION
Implement GET /person/{crn}/risks endpoint + tests

This endpoint returns the information needed to populate the [risk widget](https://github.com/ministryofjustice/hmpps-risk-ui-elements) on the frontend.  Each section of the response is enveloped so as to convey any problems fetching each section from the relevant upstream service.

 - RoSH data comes from ARNS
 - Tier comes from hmpps-tier
 - MAPPA comes from Community API
 - Flags come from Community API