### PR TITLE
Update the certificate secret name

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -6,6 +6,7 @@ generic-service:
 
   ingress:
     host: approved-premises-api-dev.hmpps.service.justice.gov.uk
+    tlsSecretName: approved-premises-api-dev-cert
 
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json


### PR DESCRIPTION
This should be overridden per environment, and is called `approved-premises-api-dev-cert` in dev.