### PR TITLE
Add lost bed reasons

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -280,7 +280,7 @@ class PremisesController(
       startDate = body.startDate,
       endDate = body.endDate,
       numberOfBeds = body.numberOfBeds,
-      reason = lostBedsTransformer.transformReasonFromApiToJpa(body.reason),
+      reasonId = body.reason,
       referenceNumber = body.referenceNumber,
       notes = body.notes
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReferenceDataController.kt
@@ -6,14 +6,17 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.ReferenceDataApiDele
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.CancellationReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.DepartureReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.DestinationProvider
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LostBedReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MoveOnCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DestinationProviderRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CancellationReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DepartureReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DestinationProviderTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.LostBedReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.MoveOnCategoryTransformer
 
 @Service
@@ -22,10 +25,12 @@ class ReferenceDataController(
   private val moveOnCategoryRepository: MoveOnCategoryRepository,
   private val destinationProviderRepository: DestinationProviderRepository,
   private val cancellationReasonRepository: CancellationReasonRepository,
+  private val lostBedReasonRepository: LostBedReasonRepository,
   private val departureReasonTransformer: DepartureReasonTransformer,
   private val moveOnCategoryTransformer: MoveOnCategoryTransformer,
   private val destinationProviderTransformer: DestinationProviderTransformer,
-  private val cancellationReasonTransformer: CancellationReasonTransformer
+  private val cancellationReasonTransformer: CancellationReasonTransformer,
+  private val lostBedReasonTransformer: LostBedReasonTransformer
 ) : ReferenceDataApiDelegate {
   override fun referenceDataDepartureReasonsGet(): ResponseEntity<List<DepartureReason>> {
     val reasons = departureReasonRepository.findAll()
@@ -49,5 +54,11 @@ class ReferenceDataController(
     val cancellationReasons = cancellationReasonRepository.findAll()
 
     return ResponseEntity.ok(cancellationReasons.map(cancellationReasonTransformer::transformJpaToApi))
+  }
+
+  override fun referenceDataLostBedReasonsGet(): ResponseEntity<List<LostBedReason>> {
+    val lostBedReasons = lostBedReasonRepository.findAll()
+
+    return ResponseEntity.ok(lostBedReasons.map(lostBedReasonTransformer::transformJpaToApi))
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/LostBedReasonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/LostBedReasonEntity.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.Table
+
+@Repository
+interface LostBedReasonRepository : JpaRepository<LostBedReasonEntity, UUID>
+
+@Entity
+@Table(name = "lost_bed_reasons")
+data class LostBedReasonEntity(
+  @Id
+  val id: UUID,
+  val name: String,
+  val isActive: Boolean
+) {
+  override fun toString() = "LostBedReasonEntity:$id"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/LostBedsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/LostBedsEntity.kt
@@ -7,10 +7,9 @@ import java.time.LocalDate
 import java.util.Objects
 import java.util.UUID
 import javax.persistence.Entity
-import javax.persistence.EnumType
-import javax.persistence.Enumerated
 import javax.persistence.Id
 import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
 import javax.persistence.OneToOne
 import javax.persistence.Table
 
@@ -31,8 +30,9 @@ data class LostBedsEntity(
   val startDate: LocalDate,
   val endDate: LocalDate,
   val numberOfBeds: Int,
-  @Enumerated(EnumType.STRING)
-  val reason: LostBedReason,
+  @ManyToOne
+  @JoinColumn(name = "lost_bed_reason_id")
+  val reason: LostBedReasonEntity,
   val referenceNumber: String?,
   val notes: String?,
   @OneToOne
@@ -57,11 +57,4 @@ data class LostBedsEntity(
   override fun hashCode() = Objects.hash(id, startDate, endDate, numberOfBeds, reason, referenceNumber, notes)
 
   override fun toString() = "ArrivalEntity:$id"
-}
-
-enum class LostBedReason() {
-  Fire,
-  Damaged,
-  Refurbishment,
-  StaffShortage
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
@@ -18,7 +18,8 @@ import java.util.UUID
 class PremisesService(
   private val premisesRepository: PremisesRepository,
   private val lostBedsRepository: LostBedsRepository,
-  private val bookingRepository: BookingRepository
+  private val bookingRepository: BookingRepository,
+  private val lostBedReasonRepository: LostBedReasonRepository
 ) {
   fun getAllPremises(): List<PremisesEntity> = premisesRepository.findAll()
   fun getPremises(premisesId: UUID): PremisesEntity? = premisesRepository.findByIdOrNull(premisesId)
@@ -52,7 +53,7 @@ class PremisesService(
     startDate: LocalDate,
     endDate: LocalDate,
     numberOfBeds: Int,
-    reason: LostBedReason,
+    reasonId: UUID,
     referenceNumber: String?,
     notes: String?
   ): ValidatableActionResult<LostBedsEntity> {
@@ -63,6 +64,11 @@ class PremisesService(
 
     if (numberOfBeds <= 0) {
       validationIssues["numberOfBeds"] = "Must be greater than 0"
+    }
+
+    val reason = lostBedReasonRepository.findByIdOrNull(reasonId)
+    if (reason == null) {
+      validationIssues["reason"] = "This reason does not exist"
     }
 
     if (validationIssues.any()) {
@@ -76,7 +82,7 @@ class PremisesService(
         startDate = startDate,
         endDate = endDate,
         numberOfBeds = numberOfBeds,
-        reason = reason,
+        reason = reason!!,
         referenceNumber = referenceNumber,
         notes = notes
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/LostBedReasonTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/LostBedReasonTransformer.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LostBedReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReasonEntity
+
+@Component
+class LostBedReasonTransformer() {
+  fun transformJpaToApi(jpa: LostBedReasonEntity) = LostBedReason(
+    id = jpa.id,
+    name = jpa.name,
+    isActive = jpa.isActive
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/LostBedsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/LostBedsTransformer.kt
@@ -2,33 +2,17 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LostBed
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LostBedReasons
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsEntity
 
 @Component
-class LostBedsTransformer {
+class LostBedsTransformer(private val lostBedReasonTransformer: LostBedReasonTransformer) {
   fun transformJpaToApi(jpa: LostBedsEntity) = LostBed(
     id = jpa.id,
     startDate = jpa.startDate,
     endDate = jpa.endDate,
     numberOfBeds = jpa.numberOfBeds,
-    reason = transformReasonFromJpaToApi(jpa.reason),
+    reason = lostBedReasonTransformer.transformJpaToApi(jpa.reason),
     referenceNumber = jpa.referenceNumber,
     notes = jpa.notes
   )
-
-  private fun transformReasonFromJpaToApi(reason: LostBedReason): LostBedReasons = when (reason) {
-    LostBedReason.Damaged -> LostBedReasons.damaged
-    LostBedReason.Fire -> LostBedReasons.fire
-    LostBedReason.Refurbishment -> LostBedReasons.refurbishment
-    LostBedReason.StaffShortage -> LostBedReasons.staffShortage
-  }
-
-  fun transformReasonFromApiToJpa(reason: LostBedReasons): LostBedReason = when (reason) {
-    LostBedReasons.damaged -> LostBedReason.Damaged
-    LostBedReasons.fire -> LostBedReason.Fire
-    LostBedReasons.refurbishment -> LostBedReason.Refurbishment
-    LostBedReasons.staffShortage -> LostBedReason.StaffShortage
-  }
 }

--- a/src/main/resources/db/migration/all/20220914094758__add_lost_bed_reasons.sql
+++ b/src/main/resources/db/migration/all/20220914094758__add_lost_bed_reasons.sql
@@ -1,0 +1,7 @@
+CREATE TABLE lost_bed_reasons (
+    id UUID NOT NULL,
+    name TEXT NOT NULL,
+    is_active BOOL NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE (name)
+);

--- a/src/main/resources/db/migration/all/20220914100140__seed_lost_bed_reasons.sql
+++ b/src/main/resources/db/migration/all/20220914100140__seed_lost_bed_reasons.sql
@@ -1,0 +1,8 @@
+INSERT INTO public.lost_bed_reasons (id, "name", is_active) VALUES
+    ('2f46e769-17a5-4b5c-b04a-a5a9a5b3f773', 'Planned Refurbishment', true),
+    ('34467c03-b919-4423-b4e2-e0dc92520a56', 'Damage by Resident', true),
+    ('2e947d1a-c547-4a09-9b76-76a609771307', 'Accident/Flood/Fire', true),
+    ('abd5af8d-8f8c-469a-8e22-85635f99ec0d', 'Staff Shortage/Illness', true),
+    ('1cefd7a4-e3ab-4908-9db8-aed0739e7ac3', 'Other', true),
+    ('ce0c151c-dda5-450c-8a7f-ca8895fecd04', 'Double Room with Single occupancy - risk', true),
+    ('55594aa8-1ae1-4a3c-b6f3-7bb55ff14807', 'Double room with single occupancy - health', true);

--- a/src/main/resources/db/migration/all/20220914110825__add_lost_bed_reason_id_to_lost_beds.sql
+++ b/src/main/resources/db/migration/all/20220914110825__add_lost_bed_reason_id_to_lost_beds.sql
@@ -1,0 +1,3 @@
+ALTER TABLE lost_beds DROP COLUMN reason;
+ALTER TABLE lost_beds ADD COLUMN lost_bed_reason_id UUID NOT NULL;
+ALTER TABLE lost_beds ADD CONSTRAINT lost_bed_reason_id_fk FOREIGN KEY (lost_bed_reason_id) REFERENCES lost_bed_reasons(id);

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1403,7 +1403,7 @@ components:
         numberOfBeds:
           type: integer
         reason:
-          $ref: '#/components/schemas/LostBedReasons'
+          $ref: '#/components/schemas/LostBedReason'
         referenceNumber:
           type: string
         notes:
@@ -1426,7 +1426,8 @@ components:
         numberOfBeds:
           type: integer
         reason:
-          $ref: '#/components/schemas/LostBedReasons'
+          type: string
+          format: uuid
         referenceNumber:
           type: string
         notes:
@@ -1436,13 +1437,6 @@ components:
         - endDate
         - numberOfBeds
         - reason
-    LostBedReasons:
-      type: string
-      enum:
-        - Fire
-        - Damaged
-        - refurbishment
-        - Staff shortage
     DepartureReason:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/LostBedReasonEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/LostBedReasonEntityFactory.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReasonEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.util.UUID
+
+class LostBedReasonEntityFactory : Factory<LostBedReasonEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+  private var isActive: Yielded<Boolean> = { true }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withName(name: String) = apply {
+    this.name = { name }
+  }
+
+  fun withIsActive(isActive: Boolean) = apply {
+    this.isActive = { isActive }
+  }
+
+  override fun produce(): LostBedReasonEntity = LostBedReasonEntity(
+    id = this.id(),
+    name = this.name(),
+    isActive = this.isActive()
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/LostBedsEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/LostBedsEntityFactory.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
@@ -17,7 +17,7 @@ class LostBedsEntityFactory : Factory<LostBedsEntity> {
   private var startDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore(6) }
   private var endDate: Yielded<LocalDate> = { LocalDate.now().randomDateAfter(6) }
   private var numberOfBeds: Yielded<Int> = { randomInt(1, 10) }
-  private var reason: Yielded<LostBedReason> = { LostBedReason.values()[randomInt(0, LostBedReason.values().size - 1)] }
+  private var reason: Yielded<LostBedReasonEntity>? = null
   private var referenceNumber: Yielded<String?> = { UUID.randomUUID().toString() }
   private var notes: Yielded<String?> = { randomStringMultiCaseWithNumbers(20) }
   private var premises: Yielded<PremisesEntity>? = null
@@ -38,8 +38,8 @@ class LostBedsEntityFactory : Factory<LostBedsEntity> {
     this.numberOfBeds = { numberOfBeds }
   }
 
-  fun withReason(reason: LostBedReason) = apply {
-    this.reason = { reason }
+  fun withYieldedReason(reason: Yielded<LostBedReasonEntity>) = apply {
+    this.reason = reason
   }
 
   fun withReferenceNumber(referenceNumber: String?) = apply {
@@ -63,7 +63,7 @@ class LostBedsEntityFactory : Factory<LostBedsEntity> {
     startDate = this.startDate(),
     endDate = this.endDate(),
     numberOfBeds = this.numberOfBeds(),
-    reason = this.reason(),
+    reason = this.reason?.invoke() ?: throw RuntimeException("Reason must be provided"),
     referenceNumber = this.referenceNumber(),
     notes = this.notes(),
     premises = this.premises?.invoke() ?: throw RuntimeException("Must provide a Premises")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DestinationProvi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ExtensionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.KeyWorkerEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LostBedReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LostBedsEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.MoveOnCategoryEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalEntityFactory
@@ -43,6 +44,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DestinationPr
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExtensionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.KeyWorkerEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalEntity
@@ -61,6 +63,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DestinationPr
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ExtensionTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.KeyWorkerTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.LocalAuthorityAreaTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.LostBedReasonTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.LostBedsTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.MoveOnCategoryTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.NonArrivalReasonTestRepository
@@ -135,6 +138,9 @@ abstract class IntegrationTestBase {
   lateinit var lostBedsRepository: LostBedsTestRepository
 
   @Autowired
+  lateinit var lostBedReasonRepository: LostBedReasonTestRepository
+
+  @Autowired
   lateinit var extensionRepository: ExtensionTestRepository
 
   @Autowired
@@ -155,6 +161,7 @@ abstract class IntegrationTestBase {
   lateinit var cancellationEntityFactory: PersistedFactory<CancellationEntity, UUID, CancellationEntityFactory>
   lateinit var cancellationReasonEntityFactory: PersistedFactory<CancellationReasonEntity, UUID, CancellationReasonEntityFactory>
   lateinit var lostBedsEntityFactory: PersistedFactory<LostBedsEntity, UUID, LostBedsEntityFactory>
+  lateinit var lostBedReasonEntityFactory: PersistedFactory<LostBedReasonEntity, UUID, LostBedReasonEntityFactory>
   lateinit var extensionEntityFactory: PersistedFactory<ExtensionEntity, UUID, ExtensionEntityFactory>
   lateinit var nonArrivalReasonEntityFactory: PersistedFactory<NonArrivalReasonEntity, UUID, NonArrivalReasonEntityFactory>
 
@@ -189,6 +196,7 @@ abstract class IntegrationTestBase {
     cancellationEntityFactory = PersistedFactory(CancellationEntityFactory(), cancellationRepository)
     cancellationReasonEntityFactory = PersistedFactory(CancellationReasonEntityFactory(), cancellationReasonRepository)
     lostBedsEntityFactory = PersistedFactory(LostBedsEntityFactory(), lostBedsRepository)
+    lostBedReasonEntityFactory = PersistedFactory(LostBedReasonEntityFactory(), lostBedReasonRepository)
     extensionEntityFactory = PersistedFactory(ExtensionEntityFactory(), extensionRepository)
     nonArrivalReasonEntityFactory = PersistedFactory(NonArrivalReasonEntityFactory(), nonArrivalReasonRepository)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
@@ -5,11 +5,15 @@ import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CancellationReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DepartureReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DestinationProviderTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.LostBedReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.MoveOnCategoryTransformer
 
 class ReferenceDataTest : IntegrationTestBase() {
   @Autowired
   lateinit var departureReasonTransformer: DepartureReasonTransformer
+
+  @Autowired
+  lateinit var lostBedReasonTransformer: LostBedReasonTransformer
 
   @Autowired
   lateinit var moveOnCategoryTransformer: MoveOnCategoryTransformer
@@ -96,6 +100,27 @@ class ReferenceDataTest : IntegrationTestBase() {
 
     webTestClient.get()
       .uri("/reference-data/cancellation-reasons")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .json(expectedJson)
+  }
+
+  @Test
+  fun `Get Lost Bed Reasons returns 200 with correct body`() {
+    lostBedReasonRepository.deleteAll()
+
+    val lostBedReasons = lostBedReasonEntityFactory.produceAndPersistMultiple(10)
+    val expectedJson = objectMapper.writeValueAsString(
+      lostBedReasons.map(lostBedReasonTransformer::transformJpaToApi)
+    )
+
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+    webTestClient.get()
+      .uri("/reference-data/lost-bed-reasons")
       .header("Authorization", "Bearer $jwt")
       .exchange()
       .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/LostBedReasonTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/LostBedReasonTestRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReasonEntity
+import java.util.UUID
+
+@Repository
+interface LostBedReasonTestRepository : JpaRepository<LostBedReasonEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
@@ -78,6 +78,7 @@ class PremisesServiceTest {
       .withPremises(premises)
       .withStartDate(startDate.plusDays(1))
       .withEndDate(startDate.plusDays(2))
+      .withYieldedReason { LostBedReasonEntityFactory().produce() }
       .withNumberOfBeds(5)
       .produce()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
@@ -5,6 +5,7 @@ import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.entry
 import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ArrivalEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
@@ -12,13 +13,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationEnti
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.KeyWorkerEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LostBedReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LostBedsEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
@@ -26,16 +28,19 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Availability
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PremisesService
 import java.time.LocalDate
+import java.util.UUID
 
 class PremisesServiceTest {
   private val premisesRepositoryMock = mockk<PremisesRepository>()
   private val lostBedsRepositoryMock = mockk<LostBedsRepository>()
   private val bookingRepositoryMock = mockk<BookingRepository>()
+  private val lostBedReasonRepositoryMock = mockk<LostBedReasonRepository>()
 
   private val premisesService = PremisesService(
     premisesRepositoryMock,
     lostBedsRepositoryMock,
-    bookingRepositoryMock
+    bookingRepositoryMock,
+    lostBedReasonRepositoryMock
   )
 
   @Test
@@ -163,12 +168,16 @@ class PremisesServiceTest {
       .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
       .produce()
 
+    val reasonId = UUID.randomUUID()
+
+    every { lostBedReasonRepositoryMock.findByIdOrNull(reasonId) } returns null
+
     val result = premisesService.createLostBeds(
       premises = premisesEntity,
       startDate = LocalDate.parse("2022-08-28"),
       endDate = LocalDate.parse("2022-08-25"),
       numberOfBeds = 0,
-      reason = LostBedReason.StaffShortage,
+      reasonId = reasonId,
       referenceNumber = "12345",
       notes = "notes"
     )
@@ -176,7 +185,8 @@ class PremisesServiceTest {
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
       entry("endDate", "Cannot be before startDate"),
-      entry("numberOfBeds", "Must be greater than 0")
+      entry("numberOfBeds", "Must be greater than 0"),
+      entry("reason", "This reason does not exist")
     )
   }
 
@@ -191,6 +201,10 @@ class PremisesServiceTest {
       .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
       .produce()
 
+    val lostBedReason = LostBedReasonEntityFactory().produce()
+
+    every { lostBedReasonRepositoryMock.findByIdOrNull(lostBedReason.id) } returns lostBedReason
+
     every { lostBedsRepositoryMock.save(any()) } answers { it.invocation.args[0] as LostBedsEntity }
 
     val result = premisesService.createLostBeds(
@@ -198,7 +212,7 @@ class PremisesServiceTest {
       startDate = LocalDate.parse("2022-08-25"),
       endDate = LocalDate.parse("2022-08-28"),
       numberOfBeds = 5,
-      reason = LostBedReason.StaffShortage,
+      reasonId = lostBedReason.id,
       referenceNumber = "12345",
       notes = "notes"
     )
@@ -206,7 +220,7 @@ class PremisesServiceTest {
     assertThat(result).isInstanceOf(ValidatableActionResult.Success::class.java)
     result as ValidatableActionResult.Success
     assertThat(result.entity.premises).isEqualTo(premisesEntity)
-    assertThat(result.entity.reason).isEqualTo(LostBedReason.StaffShortage)
+    assertThat(result.entity.reason).isEqualTo(lostBedReason)
     assertThat(result.entity.startDate).isEqualTo(LocalDate.parse("2022-08-25"))
     assertThat(result.entity.endDate).isEqualTo(LocalDate.parse("2022-08-28"))
     assertThat(result.entity.numberOfBeds).isEqualTo(5)


### PR DESCRIPTION
This adds the missing `reference-data/lost-bed-reasons` endpoint, as well as seed data to import the reasons.