### PR TITLE
Don't log health requests

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/LoggingHandlerInterceptor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/LoggingHandlerInterceptor.kt
@@ -13,7 +13,11 @@ import javax.servlet.http.HttpServletResponse
 @Configuration
 class InterceptorConfig {
   @Bean
-  fun mappedInterceptor(loggingHandlerInterceptor: LoggingHandlerInterceptor) = MappedInterceptor(null, loggingHandlerInterceptor)
+  fun mappedInterceptor(loggingHandlerInterceptor: HandlerInterceptor) = MappedInterceptor(
+    null,
+    arrayOf("/health/**"),
+    loggingHandlerInterceptor
+  )
 }
 
 @Component


### PR DESCRIPTION
/health/liveness and /health/readiness are called by Kubernetes so pollute the logs