### PR TITLE
Fix for missing PreviousConvictions & OffenderLanguages in OffenderDetailSummary failing to deserialize

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/OffenderDetailSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/OffenderDetailSummary.kt
@@ -38,12 +38,12 @@ data class OffenderProfile(
   val secondaryNationality: String?,
   val notes: String?,
   val immigrationStatus: String?,
-  val offenderLanguages: OffenderLanguages?,
+  val offenderLanguages: OffenderLanguages,
   val religion: String?,
   val sexualOrientation: String?,
   val offenderDetails: String?,
   val remandStatus: String?,
-  val previousConviction: PreviousConviction?,
+  val previousConviction: PreviousConviction,
   val riskColour: String?,
   val disabilities: List<Disability>?,
   val genderIdentity: String?,
@@ -58,8 +58,8 @@ data class OffenderLanguages(
 )
 
 data class PreviousConviction(
-  val convictionDate: LocalDate,
-  val detail: Map<String, String>
+  val convictionDate: LocalDate?,
+  val detail: Map<String, String>?
 )
 
 data class Disability(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/OffenderDetailsSummaryFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/OffenderDetailsSummaryFactory.kt
@@ -4,7 +4,9 @@ import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderIds
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderLanguages
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderProfile
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.PreviousConviction
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomOf
@@ -108,12 +110,20 @@ class OffenderDetailsSummaryFactory : Factory<OffenderDetailSummary> {
       secondaryNationality = null,
       notes = null,
       immigrationStatus = null,
-      offenderLanguages = null,
+      offenderLanguages = OffenderLanguages(
+        primaryLanguage = null,
+        otherLanguages = listOf(),
+        languageConcerns = null,
+        requiresInterpreter = null
+      ),
       religion = this.religionOrBelief(),
       sexualOrientation = null,
       offenderDetails = null,
       remandStatus = null,
-      previousConviction = null,
+      previousConviction = PreviousConviction(
+        convictionDate = null,
+        detail = null
+      ),
       riskColour = null,
       disabilities = listOf(),
       genderIdentity = this.genderIdentity(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PersonTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PersonTransformerTest.kt
@@ -5,7 +5,9 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderIds
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderLanguages
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderProfile
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.PreviousConviction
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.AssignedLivingUnit
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InOutStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
@@ -42,12 +44,20 @@ class PersonTransformerTest {
         secondaryNationality = null,
         notes = null,
         immigrationStatus = null,
-        offenderLanguages = null,
+        offenderLanguages = OffenderLanguages(
+          primaryLanguage = null,
+          otherLanguages = listOf(),
+          languageConcerns = null,
+          requiresInterpreter = null
+        ),
         religion = "Sikh",
         sexualOrientation = null,
         offenderDetails = null,
         remandStatus = null,
-        previousConviction = null,
+        previousConviction = PreviousConviction(
+          convictionDate = null,
+          detail = null
+        ),
         riskColour = null,
         disabilities = listOf(),
         genderIdentity = null,
@@ -112,12 +122,20 @@ class PersonTransformerTest {
         secondaryNationality = null,
         notes = null,
         immigrationStatus = null,
-        offenderLanguages = null,
+        offenderLanguages = OffenderLanguages(
+          primaryLanguage = null,
+          otherLanguages = listOf(),
+          languageConcerns = null,
+          requiresInterpreter = null
+        ),
         religion = "Sikh",
         sexualOrientation = null,
         offenderDetails = null,
         remandStatus = null,
-        previousConviction = null,
+        previousConviction = PreviousConviction(
+          convictionDate = null,
+          detail = null
+        ),
         riskColour = null,
         disabilities = listOf(),
         genderIdentity = "Female",
@@ -182,12 +200,20 @@ class PersonTransformerTest {
         secondaryNationality = null,
         notes = null,
         immigrationStatus = null,
-        offenderLanguages = null,
+        offenderLanguages = OffenderLanguages(
+          primaryLanguage = null,
+          otherLanguages = listOf(),
+          languageConcerns = null,
+          requiresInterpreter = null
+        ),
         religion = "Sikh",
         sexualOrientation = null,
         offenderDetails = null,
         remandStatus = null,
-        previousConviction = null,
+        previousConviction = PreviousConviction(
+          convictionDate = null,
+          detail = null
+        ),
         riskColour = null,
         disabilities = listOf(),
         genderIdentity = "Female",
@@ -252,12 +278,20 @@ class PersonTransformerTest {
         secondaryNationality = null,
         notes = null,
         immigrationStatus = null,
-        offenderLanguages = null,
+        offenderLanguages = OffenderLanguages(
+          primaryLanguage = null,
+          otherLanguages = listOf(),
+          languageConcerns = null,
+          requiresInterpreter = null
+        ),
         religion = "Sikh",
         sexualOrientation = null,
         offenderDetails = null,
         remandStatus = null,
-        previousConviction = null,
+        previousConviction = PreviousConviction(
+          convictionDate = null,
+          detail = null
+        ),
         riskColour = null,
         disabilities = listOf(),
         genderIdentity = null,


### PR DESCRIPTION
Community API returns an empty object for these rather a null (which is actually an object where each property is null, but Jackson is configured to omit null properties on Community API), so nullability needs to be pushed down into the properties on our side.