### PR TITLE
Return detailed problem responses when request body does not conform to OpenAPI spec

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,8 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
 
+  implementation(kotlin("reflect"))
+
   testImplementation("io.github.bluegroundltd:kfactory:1.0.0")
   testImplementation("io.mockk:mockk:1.12.5")
   testImplementation("io.jsonwebtoken:jjwt-api:0.11.5")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/ContentCachingFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/ContentCachingFilter.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.config
+
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import org.springframework.web.util.ContentCachingRequestWrapper
+import javax.servlet.FilterChain
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+@Component
+@Order(1)
+class ContentCachingFilter : OncePerRequestFilter() {
+  override fun doFilterInternal(
+    httpServletRequest: HttpServletRequest,
+    httpServletResponse: HttpServletResponse,
+    filterChain: FilterChain
+  ) {
+    filterChain.doFilter(ContentCachingRequestWrapper(httpServletRequest), httpServletResponse)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ExceptionHandling.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ExceptionHandling.kt
@@ -1,6 +1,10 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.problem
 
-import com.fasterxml.jackson.databind.exc.InvalidFormatException
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.exc.MismatchedInputException
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
@@ -8,6 +12,7 @@ import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.util.ContentCachingRequestWrapper
 import org.zalando.problem.Problem
 import org.zalando.problem.Status
 import org.zalando.problem.StatusType
@@ -15,9 +20,13 @@ import org.zalando.problem.ThrowableProblem
 import org.zalando.problem.spring.common.AdviceTrait
 import org.zalando.problem.spring.web.advice.ProblemHandling
 import org.zalando.problem.spring.web.advice.io.MessageNotReadableAdviceTrait
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DeserializationValidationService
 
 @ControllerAdvice
-class ExceptionHandling : ProblemHandling, MessageNotReadableAdviceTrait {
+class ExceptionHandling(
+  private val objectMapper: ObjectMapper,
+  private val deserializationValidationService: DeserializationValidationService
+) : ProblemHandling, MessageNotReadableAdviceTrait {
   override fun toProblem(throwable: Throwable, status: StatusType): ThrowableProblem? {
     if (throwable is AuthenticationCredentialsNotFoundException) {
       return UnauthenticatedProblem()
@@ -38,24 +47,67 @@ class ExceptionHandling : ProblemHandling, MessageNotReadableAdviceTrait {
       .withStatus(Status.BAD_REQUEST)
       .withTitle("Bad Request")
 
-    if (exception.cause is InvalidFormatException) {
-      val invalidFormatException = exception.cause as InvalidFormatException
-      responseBuilder
-        .withDetail("There is a problem with your request")
-        .with(
-          "invalid-params",
-          ParamError(
-            propertyName = invalidFormatException.path.joinToString(".") { it.fieldName },
-            errorType = invalidFormatException.cause?.message ?: "Unknown problem"
+    when (exception.cause) {
+      is MismatchedInputException -> {
+        val mismatchedInputException = exception.cause as MismatchedInputException
+
+        val requestBody = request.getNativeRequest(ContentCachingRequestWrapper::class.java)
+        val jsonTree = objectMapper.readTree(String(requestBody.contentAsByteArray))
+
+        if (expectedArrayButGotObject(jsonTree, mismatchedInputException)) {
+          responseBuilder.withDetail("Expected an array but got an object")
+          return ResponseEntity<Problem>(responseBuilder.build(), HttpStatus.BAD_REQUEST)
+        }
+
+        if (expectedObjectButGotArray(jsonTree, mismatchedInputException)) {
+          responseBuilder.withDetail("Expected an object but got an array")
+          return ResponseEntity<Problem>(responseBuilder.build(), HttpStatus.BAD_REQUEST)
+        }
+
+        val badRequestProblem = if (rootIsArray(mismatchedInputException)) {
+          val arrayItemsType = (mismatchedInputException.path[1].from as Class<*>).kotlin
+
+          BadRequestProblem(
+            invalidParams = deserializationValidationService.validateArray(
+              targetType = arrayItemsType,
+              jsonArray = jsonTree as ArrayNode
+            )
           )
-        )
-    } else {
-      responseBuilder
-        .withDetail(exception.message)
+        } else {
+          val objectType = (mismatchedInputException.path[0].from as Class<*>).kotlin
+
+          BadRequestProblem(
+            invalidParams = deserializationValidationService.validateObject(
+              targetType = objectType,
+              jsonObject = jsonTree as ObjectNode
+            )
+          )
+        }
+
+        return ResponseEntity(badRequestProblem, HttpStatus.BAD_REQUEST)
+      }
+      else ->
+        responseBuilder.withDetail(exception.message)
     }
 
     return ResponseEntity<Problem>(responseBuilder.build(), HttpStatus.BAD_REQUEST)
   }
+
+  private fun isInputTypeArray(mismatchedInputException: MismatchedInputException): Boolean {
+    if (mismatchedInputException.path.isEmpty()) {
+      return deserializationValidationService.isArrayType(mismatchedInputException.targetType)
+    }
+
+    if (mismatchedInputException.path.first().from is Class<*>) {
+      return deserializationValidationService.isArrayType(mismatchedInputException.path.first().from as Class<*>)
+    }
+
+    return true
+  }
+
+  private fun expectedArrayButGotObject(jsonNode: JsonNode, mismatchedInputException: MismatchedInputException) = jsonNode is ObjectNode && isInputTypeArray(mismatchedInputException)
+  private fun expectedObjectButGotArray(jsonNode: JsonNode, mismatchedInputException: MismatchedInputException) = jsonNode is ArrayNode && !isInputTypeArray(mismatchedInputException)
+  private fun rootIsArray(mismatchedInputException: MismatchedInputException) = mismatchedInputException.path[0].from !is Class<*>
 }
 
 private class AdviceTraitDefault : AdviceTrait

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -56,7 +56,7 @@ class BookingService(
     }
 
     if (expectedDepartureDate.isBefore(arrivalDate)) {
-      return ValidatableActionResult.FieldValidationError(mapOf("expectedDepartureDate" to "Cannot be before arrivalDate"))
+      return ValidatableActionResult.FieldValidationError(mapOf("$.expectedDepartureDate" to "Cannot be before arrivalDate"))
     }
 
     val arrivalEntity = arrivalRepository.save(
@@ -85,12 +85,12 @@ class BookingService(
     val validationIssues = mutableMapOf<String, String>()
 
     if (booking.arrivalDate.isAfter(date)) {
-      validationIssues["date"] = "Cannot be before Booking's arrivalDate"
+      validationIssues["$.date"] = "Cannot be before Booking's arrivalDate"
     }
 
     val reason = nonArrivalReasonRepository.findByIdOrNull(reasonId)
     if (reason == null) {
-      validationIssues["reason"] = "This reason does not exist"
+      validationIssues["$.reason"] = "This reason does not exist"
     }
 
     if (validationIssues.any()) {
@@ -124,7 +124,7 @@ class BookingService(
 
     val reason = cancellationReasonRepository.findByIdOrNull(reasonId)
     if (reason == null) {
-      validationIssues["reason"] = "This reason does not exist"
+      validationIssues["$.reason"] = "This reason does not exist"
     }
 
     if (validationIssues.any()) {
@@ -159,22 +159,22 @@ class BookingService(
     val validationIssues = mutableMapOf<String, String>()
 
     if (booking.arrivalDate.toLocalDateTime().isAfter(dateTime)) {
-      validationIssues["dateTime"] = "Must be after the Booking's arrival date (${booking.arrivalDate})"
+      validationIssues["$.dateTime"] = "Must be after the Booking's arrival date (${booking.arrivalDate})"
     }
 
     val reason = departureReasonRepository.findByIdOrNull(reasonId)
     if (reason == null) {
-      validationIssues["reasonId"] = "Reason does not exist"
+      validationIssues["$.reasonId"] = "Reason does not exist"
     }
 
     val moveOnCategory = moveOnCategoryRepository.findByIdOrNull(moveOnCategoryId)
     if (reason == null) {
-      validationIssues["moveOnCategoryId"] = "Move on Category does not exist"
+      validationIssues["$.moveOnCategoryId"] = "Move on Category does not exist"
     }
 
     val destinationProvider = destinationProviderRepository.findByIdOrNull(destinationProviderId)
     if (destinationProvider == null) {
-      validationIssues["destinationProviderId"] = "Destination Provider does not exist"
+      validationIssues["$.destinationProviderId"] = "Destination Provider does not exist"
     }
 
     if (validationIssues.any()) {
@@ -203,7 +203,7 @@ class BookingService(
     notes: String?
   ): ValidatableActionResult<ExtensionEntity> {
     if (booking.departureDate.isAfter(newDepartureDate)) {
-      return ValidatableActionResult.FieldValidationError(mapOf("newDepartureDate" to "Must be after the Booking's current departure date (${booking.departureDate})"))
+      return ValidatableActionResult.FieldValidationError(mapOf("$.newDepartureDate" to "Must be after the Booking's current departure date (${booking.departureDate})"))
     }
 
     val extensionEntity = ExtensionEntity(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DeserializationValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DeserializationValidationService.kt
@@ -1,0 +1,115 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.JsonNodeType
+import com.fasterxml.jackson.databind.node.NullNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import org.springframework.stereotype.Service
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import kotlin.reflect.KClass
+import kotlin.reflect.full.declaredMemberProperties
+import kotlin.reflect.jvm.jvmErasure
+
+@Service
+class DeserializationValidationService {
+  fun validateArray(path: String = "$", targetType: KClass<*>, jsonArray: ArrayNode, elementsNullable: Boolean = true): Map<String, String> {
+    val result = mutableMapOf<String, String>()
+
+    if (getExpectedJsonPrimitiveType(targetType.java) != null) {
+      jsonArray.forEachIndexed { index, jsonNode ->
+        val expectedJsonPrimitiveType = getExpectedJsonPrimitiveType(targetType.java)
+        if (jsonNode.nodeType != expectedJsonPrimitiveType) {
+          result["$path[$index]"] = "Expected a ${expectedJsonPrimitiveType!!.name.lowercase()}"
+        }
+      }
+
+      return result
+    }
+
+    jsonArray.forEachIndexed { index, jsonNode ->
+      if (nullOrNullNode(jsonNode)) {
+        if (!elementsNullable) {
+          result["$path[$index]"] = "Expected an object"
+        }
+        return@forEachIndexed
+      }
+      result.putAll(validateObject("$path[$index]", targetType, jsonNode as ObjectNode))
+    }
+    return result
+  }
+
+  fun validateObject(path: String = "$", targetType: KClass<*>, jsonObject: ObjectNode): Map<String, String> {
+    val result = mutableMapOf<String, String>()
+
+    targetType.declaredMemberProperties.forEach {
+      val jsonNode = jsonObject.get(it.name)
+
+      if (it.returnType.isMarkedNullable && nullOrNullNode(jsonNode)) {
+        return@forEach
+      }
+
+      if (!it.returnType.isMarkedNullable && nullOrNullNode(jsonNode)) {
+        result["$path.${it.name}"] = "A value must be provided for this property"
+        return@forEach
+      }
+
+      if (!nullOrNullNode(jsonNode)) {
+        if (isArrayType(it.returnType.jvmErasure.java)) {
+          if (jsonObject.get(it.name) !is ArrayNode) {
+            result["$path.${it.name}"] = "Expected an array"
+            return@forEach
+          }
+
+          val genericType = it.returnType.arguments.first().type!!.jvmErasure
+          result.putAll(validateArray("$path.${it.name}", genericType, jsonObject.get(it.name) as ArrayNode, it.returnType.arguments.first().type!!.isMarkedNullable))
+          return@forEach
+        }
+
+        if (getExpectedJsonPrimitiveType(it.returnType.jvmErasure.java) == null) {
+          if (jsonObject.get(it.name) !is ObjectNode) {
+            result["$path.${it.name}"] = "Expected an object"
+            return@forEach
+          }
+
+          result.putAll(
+            validateObject("$path.${it.name}", it.returnType.jvmErasure.java.kotlin, jsonObject.get(it.name) as ObjectNode)
+          )
+          return@forEach
+        }
+
+        val expectedJsonPrimitiveType = getExpectedJsonPrimitiveType(it.returnType.jvmErasure.java)
+        if (jsonNode.nodeType != expectedJsonPrimitiveType) {
+          result["$path.${it.name}"] = "Expected a ${expectedJsonPrimitiveType!!.name.lowercase()}"
+        }
+      }
+    }
+
+    return result
+  }
+
+  private fun getExpectedJsonPrimitiveType(jvmPrimitive: Class<*>): JsonNodeType? {
+    return when (jvmPrimitive) {
+      String::class.java -> JsonNodeType.STRING
+      LocalDate::class.java -> JsonNodeType.STRING
+      LocalDateTime::class.java -> JsonNodeType.STRING
+      OffsetDateTime::class.java -> JsonNodeType.STRING
+      Boolean::class.java -> JsonNodeType.BOOLEAN
+      Boolean::class.javaObjectType -> JsonNodeType.BOOLEAN
+      BigDecimal::class.java -> JsonNodeType.NUMBER
+      Int::class.java -> JsonNodeType.NUMBER
+      Int::class.javaObjectType -> JsonNodeType.NUMBER
+      else -> null
+    }
+  }
+
+  private fun nullOrNullNode(jsonNode: JsonNode?) = jsonNode == null || jsonNode is NullNode
+
+  private val arrayTypes = listOf(java.util.List::class.java, java.util.HashSet::class.java)
+  fun isArrayType(type: Class<*>): Boolean {
+    return arrayTypes.any { arrayType -> arrayType.isAssignableFrom(type) } || type.isArray
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
@@ -59,16 +59,16 @@ class PremisesService(
   ): ValidatableActionResult<LostBedsEntity> {
     val validationIssues = mutableMapOf<String, String>()
     if (endDate.isBefore(startDate)) {
-      validationIssues["endDate"] = "Cannot be before startDate"
+      validationIssues["$.endDate"] = "Cannot be before startDate"
     }
 
     if (numberOfBeds <= 0) {
-      validationIssues["numberOfBeds"] = "Must be greater than 0"
+      validationIssues["$.numberOfBeds"] = "Must be greater than 0"
     }
 
     val reason = lostBedReasonRepository.findByIdOrNull(reasonId)
     if (reason == null) {
-      validationIssues["reason"] = "This reason does not exist"
+      validationIssues["$.reason"] = "This reason does not exist"
     }
 
     if (validationIssues.any()) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProblemResponsesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProblemResponsesTest.kt
@@ -1,0 +1,193 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.ResponseEntity
+import org.springframework.test.web.reactive.server.returnResult
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.InvalidParam
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ValidationError
+import java.time.LocalDate
+
+class ProblemResponsesTest : IntegrationTestBase() {
+  @Test
+  fun `An invalid request body will return a 400 when the expected body root is an object and an array is provided`() {
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+    val validationResult = webTestClient.post()
+      .uri("/deserialization-test/object")
+      .header("Authorization", "Bearer $jwt")
+      .header("Content-Type", "application/json")
+      .bodyValue("[]")
+      .exchange()
+      .expectStatus()
+      .isBadRequest
+      .returnResult<ValidationError>()
+      .responseBody
+      .blockFirst()
+
+    assertThat(validationResult.detail).isEqualTo("Expected an object but got an array")
+  }
+
+  @Test
+  fun `An invalid request body will return a 400 when the expected body root is an array and an object is provided`() {
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+    val validationResult = webTestClient.post()
+      .uri("/deserialization-test/array")
+      .header("Authorization", "Bearer $jwt")
+      .header("Content-Type", "application/json")
+      .bodyValue("{}")
+      .exchange()
+      .expectStatus()
+      .isBadRequest
+      .returnResult<ValidationError>()
+      .responseBody
+      .blockFirst()
+
+    assertThat(validationResult.detail).isEqualTo("Expected an array but got an object")
+  }
+
+  @Test
+  fun `An invalid request body will return a 400 with details of all problems when the expected body root is an object and an object is provided`() {
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+    val validationResult = webTestClient.post()
+      .uri("/deserialization-test/object")
+      .header("Authorization", "Bearer $jwt")
+      .header("Content-Type", "application/json")
+      .bodyValue(
+        """
+          {
+             "requiredInt": null,
+             "optionalInt": 123,
+             "optionalObject": [],
+             "requiredObject": {
+                "requiredString": null,
+                "optionalBoolean": 1234,
+                "optionalLocalDate": false
+             },
+             "requiredListOfInts": ["not", "ints", false],
+             "requiredListOfObjects": null,
+             "optionalListOfObjects": [{
+                  "requiredString": null,
+                  "optionalBoolean": 1234,
+                  "optionalLocalDate": false
+               }, 
+               null]
+          }
+        """
+      )
+      .exchange()
+      .expectStatus()
+      .isBadRequest
+      .returnResult<ValidationError>()
+      .responseBody
+      .blockFirst()
+
+    assertThat(validationResult!!.invalidParams).containsAll(
+      listOf(
+        InvalidParam(propertyName = "$.optionalListOfObjects[0].optionalBoolean", errorType = "Expected a boolean"),
+        InvalidParam(propertyName = "$.optionalListOfObjects[0].optionalLocalDate", errorType = "Expected a string"),
+        InvalidParam(propertyName = "$.optionalListOfObjects[0].requiredString", errorType = "A value must be provided for this property"),
+        InvalidParam(propertyName = "$.optionalListOfObjects[1]", errorType = "Expected an object"),
+        InvalidParam(propertyName = "$.optionalObject", errorType = "Expected an object"),
+        InvalidParam(propertyName = "$.requiredInt", errorType = "A value must be provided for this property"),
+        InvalidParam(propertyName = "$.requiredListOfInts[0]", errorType = "Expected a number"),
+        InvalidParam(propertyName = "$.requiredListOfInts[1]", errorType = "Expected a number"),
+        InvalidParam(propertyName = "$.requiredListOfInts[2]", errorType = "Expected a number"),
+        InvalidParam(propertyName = "$.requiredListOfObjects", errorType = "A value must be provided for this property"),
+        InvalidParam(propertyName = "$.requiredObject.optionalBoolean", errorType = "Expected a boolean"),
+        InvalidParam(propertyName = "$.requiredObject.optionalLocalDate", errorType = "Expected a string"),
+        InvalidParam(propertyName = "$.requiredObject.requiredString", errorType = "A value must be provided for this property")
+      )
+    )
+  }
+
+  @Test
+  fun `An invalid request body will return a 400 with details of all problems when the expected body root is an array and an array is provided`() {
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+    val validationResult = webTestClient.post()
+      .uri("/deserialization-test/array")
+      .header("Authorization", "Bearer $jwt")
+      .header("Content-Type", "application/json")
+      .bodyValue(
+        """
+          [{
+             "requiredInt": null,
+             "optionalInt": 123,
+             "optionalObject": [],
+             "requiredObject": {
+                "requiredString": null,
+                "optionalBoolean": 1234,
+                "optionalLocalDate": false
+             },
+             "requiredListOfInts": ["not", "ints", false],
+             "requiredListOfObjects": null,
+             "optionalListOfObjects": [{
+                  "requiredString": null,
+                  "optionalBoolean": 1234,
+                  "optionalLocalDate": false
+               }, 
+               null]
+          }]
+        """
+      )
+      .exchange()
+      .expectStatus()
+      .isBadRequest
+      .returnResult<ValidationError>()
+      .responseBody
+      .blockFirst()
+
+    assertThat(validationResult!!.invalidParams).containsAll(
+      listOf(
+        InvalidParam(propertyName = "$[0].optionalListOfObjects[0].optionalBoolean", errorType = "Expected a boolean"),
+        InvalidParam(propertyName = "$[0].optionalListOfObjects[0].optionalLocalDate", errorType = "Expected a string"),
+        InvalidParam(propertyName = "$[0].optionalListOfObjects[0].requiredString", errorType = "A value must be provided for this property"),
+        InvalidParam(propertyName = "$[0].optionalListOfObjects[1]", errorType = "Expected an object"),
+        InvalidParam(propertyName = "$[0].optionalObject", errorType = "Expected an object"),
+        InvalidParam(propertyName = "$[0].requiredInt", errorType = "A value must be provided for this property"),
+        InvalidParam(propertyName = "$[0].requiredListOfInts[0]", errorType = "Expected a number"),
+        InvalidParam(propertyName = "$[0].requiredListOfInts[1]", errorType = "Expected a number"),
+        InvalidParam(propertyName = "$[0].requiredListOfInts[2]", errorType = "Expected a number"),
+        InvalidParam(propertyName = "$[0].requiredListOfObjects", errorType = "A value must be provided for this property"),
+        InvalidParam(propertyName = "$[0].requiredObject.optionalBoolean", errorType = "Expected a boolean"),
+        InvalidParam(propertyName = "$[0].requiredObject.optionalLocalDate", errorType = "Expected a string"),
+        InvalidParam(propertyName = "$[0].requiredObject.requiredString", errorType = "A value must be provided for this property")
+      )
+    )
+  }
+}
+
+@RestController
+class DeserializationTestController {
+  @PostMapping(path = ["deserialization-test/object"], consumes = ["application/json"])
+  fun testDeserialization(@RequestBody body: DeserializationTestBody): ResponseEntity<Unit> {
+    return ResponseEntity.ok(Unit)
+  }
+
+  @PostMapping(path = ["deserialization-test/array"], consumes = ["application/json"])
+  fun testDeserialization(@RequestBody body: List<DeserializationTestBody>): ResponseEntity<Unit> {
+    return ResponseEntity.ok(Unit)
+  }
+}
+
+data class DeserializationTestBody(
+  val requiredInt: Int,
+  val optionalInt: Int?,
+  val optionalObject: DeserializationTestBodyNested?,
+  val requiredObject: DeserializationTestBodyNested,
+  val requiredListOfInts: List<Int>,
+  val requiredListOfObjects: List<DeserializationTestBodyNested>,
+  val optionalListOfObjects: List<DeserializationTestBodyNested>?
+)
+
+data class DeserializationTestBodyNested(
+  val requiredString: String,
+  val optionalBoolean: Boolean?,
+  val optionalLocalDate: LocalDate?
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -236,10 +236,10 @@ class BookingServiceTest {
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("dateTime", "Must be after the Booking's arrival date (2022-08-25)"),
-      entry("reasonId", "Reason does not exist"),
-      entry("moveOnCategoryId", "Move on Category does not exist"),
-      entry("destinationProviderId", "Destination Provider does not exist")
+      entry("$.dateTime", "Must be after the Booking's arrival date (2022-08-25)"),
+      entry("$.reasonId", "Reason does not exist"),
+      entry("$.moveOnCategoryId", "Move on Category does not exist"),
+      entry("$.destinationProviderId", "Destination Provider does not exist")
     )
   }
 
@@ -352,7 +352,7 @@ class BookingServiceTest {
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("expectedDepartureDate", "Cannot be before arrivalDate")
+      entry("$.expectedDepartureDate", "Cannot be before arrivalDate")
     )
   }
 
@@ -452,8 +452,8 @@ class BookingServiceTest {
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("date", "Cannot be before Booking's arrivalDate"),
-      entry("reason", "This reason does not exist")
+      entry("$.date", "Cannot be before Booking's arrivalDate"),
+      entry("$.reason", "This reason does not exist")
     )
   }
 
@@ -559,7 +559,7 @@ class BookingServiceTest {
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("reason", "This reason does not exist")
+      entry("$.reason", "This reason does not exist")
     )
   }
 
@@ -625,7 +625,7 @@ class BookingServiceTest {
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("newDepartureDate", "Must be after the Booking's current departure date (2022-08-26)")
+      entry("$.newDepartureDate", "Must be after the Booking's current departure date (2022-08-26)")
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
@@ -184,9 +184,9 @@ class PremisesServiceTest {
 
     assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("endDate", "Cannot be before startDate"),
-      entry("numberOfBeds", "Must be greater than 0"),
-      entry("reason", "This reason does not exist")
+      entry("$.endDate", "Cannot be before startDate"),
+      entry("$.numberOfBeds", "Must be greater than 0"),
+      entry("$.reason", "This reason does not exist")
     )
   }
 


### PR DESCRIPTION
**Return more detailed problem responses when request bodies that don't conform to the OpenAPI spec are provided**

Jackson (the deserializer used by Spring) fails fast when deserializing into POJO, so it's only possible out of the box to provide the first error encountered during deserialization back to the caller.  This catches those exceptions then uses reflection to check each property and provide more detailed responses.  For this to work, we need to read the input stream more than once, so this also uses ContentCachingRequestWrapper to read the input stream once and cache it for reuse.

**Update existing validation responses to return a JSON Path parameter name**

Currently, all request bodies are simple non-nested objects, but its likely this won't always be the case.  The type validation code returns JSON Path names since it works to arbitrary levels so this needs to be consistent across the rest of the API.