### PR TITLE
Handle 403 from Community API userAccess point correctly

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/BaseHMPPSClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/BaseHMPPSClient.kt
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.client
 
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
@@ -81,6 +83,8 @@ interface ClientResult<ResponseType> {
     override fun throwException(): Nothing {
       throw RuntimeException("Unable to complete $method request to $path: $status")
     }
+
+    inline fun <reified ResponseType> deserializeTo(): ResponseType = jacksonObjectMapper().readValue(body, ResponseType::class.java)
   }
   class OtherFailure<ResponseType>(val method: HttpMethod, val path: String, val exception: Exception) : Failure<ResponseType> {
     override fun throwException(): Nothing {


### PR DESCRIPTION
Will now return a 403 rather than a 500 when LAO restricted offender requested