### PR TITLE
Rename NewBooking arrival and departure dates

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -160,8 +160,8 @@ class PremisesController(
       BookingEntity(
         id = UUID.randomUUID(),
         crn = offenderResult.entity.otherIds.crn,
-        arrivalDate = body.expectedArrivalDate,
-        departureDate = body.expectedDepartureDate,
+        arrivalDate = body.arrivalDate,
+        departureDate = body.departureDate,
         keyWorker = keyWorker!!,
         arrival = null,
         departure = null,

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1085,11 +1085,11 @@ components:
         crn:
           type: string
           example: A123456
-        expectedArrivalDate:
+        arrivalDate:
           type: string
           format: date
           example: 2022-07-28
-        expectedDepartureDate:
+        departureDate:
           type: string
           format: date
           example: 2022-09-30
@@ -1098,8 +1098,8 @@ components:
           format: uuid
       required:
         - crn
-        - expectedArrivalDate
-        - expectedDepartureDate
+        - arrivalDate
+        - departureDate
         - keyWorkerId
     Booking:
       allOf:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -201,8 +201,8 @@ class BookingTest : IntegrationTestBase() {
       .bodyValue(
         NewBooking(
           crn = "a crn",
-          expectedArrivalDate = LocalDate.parse("2022-08-12"),
-          expectedDepartureDate = LocalDate.parse("2022-08-30"),
+          arrivalDate = LocalDate.parse("2022-08-12"),
+          departureDate = LocalDate.parse("2022-08-30"),
           keyWorkerId = keyWorker.id
         )
       )
@@ -242,8 +242,8 @@ class BookingTest : IntegrationTestBase() {
       .bodyValue(
         NewBooking(
           crn = "CRN321",
-          expectedArrivalDate = LocalDate.parse("2022-08-12"),
-          expectedDepartureDate = LocalDate.parse("2022-08-30"),
+          arrivalDate = LocalDate.parse("2022-08-12"),
+          departureDate = LocalDate.parse("2022-08-30"),
           keyWorkerId = UUID.randomUUID()
         )
       )
@@ -294,8 +294,8 @@ class BookingTest : IntegrationTestBase() {
       .bodyValue(
         NewBooking(
           crn = "CRN321",
-          expectedArrivalDate = LocalDate.parse("2022-08-12"),
-          expectedDepartureDate = LocalDate.parse("2022-08-30"),
+          arrivalDate = LocalDate.parse("2022-08-12"),
+          departureDate = LocalDate.parse("2022-08-30"),
           keyWorkerId = keyWorker.id
         )
       )


### PR DESCRIPTION
This ensures they are consistent with the values in the actual Booking model